### PR TITLE
fix: activate exact source windows and refresh titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Built on the system [ScreenCaptureKit](https://developer.apple.com/documentation
 
 **Interaction**
 - A dimmed overlay with an arrow points at the menu bar icon on first launch, so it is obvious the app is running in the background; replay it any time from *Show Getting Started*.
-- Click a PiP window to switch straight to its source app (optional); with Accessibility granted it also raises that specific window.
+- Click a PiP window to switch straight to its source app (optional); with Accessibility granted it identifies the source by window ID and raises that exact window. PiP titles follow source title changes automatically.
 - Auto-hide with click-through: the window fades out and pauses when the pointer moves over it — but the **top bar stays usable**: rest the pointer on the bar and the window returns to full opacity so you can click buttons, drag it by the bar, or open the right-click menu, while the video area stays click-through.
 - While faded you can also hold `⌥` to peek at the whole window, or turn auto-hide off from the window's menu bar submenu. The faded opacity is configurable in 5% steps (default 35%).
 - Hover overlay controls: pause, frame rate, reset zoom, auto-hide, idle detection, close. Icons highlight on hover and the description appears instantly above the icon.
@@ -86,7 +86,7 @@ Enhanced mode (optional, requires Accessibility) adds `fn`+`P` / `fn`+`⇧`+`P` 
 | Permission | Required | Purpose |
 |---|---|---|
 | Screen & System Audio Recording | **yes** | ScreenCaptureKit window capture |
-| Accessibility | optional | enhanced mode only (fn hotkeys, hover keys) |
+| Accessibility | optional | exact source-window switching; Enhanced mode (fn hotkeys, hover keys) |
 
 The system prompt appears on first launch and the app registers itself under *System Settings → Privacy & Security → Screen & System Audio Recording*, so you just flip the switch — no need to add it manually with the "+" button. macOS only applies the grant after a restart; the guide dialog has a "Relaunch app" button for that.
 
@@ -202,7 +202,7 @@ Pushing a `v*` tag (matching `VERSION`) builds the universal binary and publishe
 
 **交互**
 - 首次启动有一层遮罩 + 箭头引导指向菜单栏图标，明确告知「应用已在后台运行、入口在这里」；之后可从菜单栏「显示上手引导」重看。
-- 单击浮窗直接切回源应用窗口（可关闭）；已授予辅助功能权限时会连那个具体窗口一起抬到最前。
+- 单击浮窗直接切回源应用窗口（可关闭）；已授予辅助功能权限时会按窗口 ID 精确抬起对应窗口。浮窗标题会自动跟随源窗口标题变化。
 - 自动隐藏 + 点击穿透：鼠标移上去浮窗淡出并暂停，可直接操作背后的内容；此时**顶栏仍然可用**——鼠标停在顶栏范围内浮窗就会恢复不透明，可以点按钮、按住顶栏拖动窗口、调出右键菜单，画面区域依旧穿透。
 - 淡出后也可以按住 `⌥` 临时唤回整窗，或在菜单栏的浮窗子菜单里关掉自动隐藏。淡出透明度可调，5% 一档（默认 35%）。
 - 悬停浮出控制条：暂停、帧率、复位缩放、自动隐藏、静止检测、关闭；图标有悬停高亮，说明文字立刻显示在图标上方。
@@ -231,7 +231,7 @@ Pushing a `v*` tag (matching `VERSION`) builds the universal binary and publishe
 | 权限 | 是否必需 | 用途 |
 |---|---|---|
 | 屏幕录制与系统录音 | **必需** | ScreenCaptureKit 捕获窗口画面 |
-| 辅助功能 | 可选 | 仅增强模式（fn 组合键、悬停按键）需要 |
+| 辅助功能 | 可选 | 精确切换到源窗口；增强模式（fn 组合键、悬停按键） |
 
 首次启动会弹出系统的屏幕录制授权框，本应用会自动出现在「系统设置 → 隐私与安全性 → 屏幕录制与系统录音」列表里，**直接打开开关即可，不需要手动点加号添加**。macOS 要求授权后重启应用才生效，引导框里有「重新启动应用」按钮。
 
@@ -314,7 +314,7 @@ bash packaging/make-dmg.sh             # 生成 dist/MyWindowPip-<版本>.dmg + 
 ### 说明
 
 - 需要 macOS 14+：为了用 `SCStream.updateConfiguration` 平滑改帧率/分辨率/裁剪，不做 12.3–13 的兼容分支。
-- `fn` 组合键与「悬停按键」必须走事件监听，所以只放在需要辅助功能权限的增强模式里；其余功能只靠屏幕录制权限就能全用。
+- `fn` 组合键、「悬停按键」与精确切换到具体源窗口需要辅助功能权限；未授权时，单击浮窗仍会激活源应用，但由应用决定显示哪个窗口。
 - 源窗口最小化时系统不再产出画面，只能显示占位并等待恢复（这是 macOS 的限制，不是 bug）。
 - 顶栏的「复位缩放」指的是**画面放大倍率**，与浮窗窗口大小无关；没有用 `Cmd` 拖拽或 `Cmd` 滚轮放大过画面时它是灰色不可用的。
 - 登录自启动依赖 `SMAppService`，ad-hoc 签名下可能失败，失败时会提示改用系统设置手动添加。

--- a/Sources/my-window-pip/Permissions.swift
+++ b/Sources/my-window-pip/Permissions.swift
@@ -103,29 +103,33 @@ enum Permissions {
         }
     }
 
-    // MARK: - 辅助功能（增强模式）
+    // MARK: - 辅助功能（精确回源 / 增强模式）
 
     static var hasAccessibility: Bool { AXIsProcessTrusted() }
 
     static func showAccessibilityGuide() {
         let alert = NSAlert()
         alert.alertStyle = .informational
-        alert.messageText = L.t("增强模式需要「辅助功能」权限", "Enhanced mode requires Accessibility")
+        alert.messageText = L.t("这些功能需要「辅助功能」权限", "These features require Accessibility")
         alert.informativeText = L.t(
             """
-            增强模式用于支持 fn 组合热键，以及鼠标悬停在浮窗上时的快捷键（= - F D fn ⌫）。
+            「辅助功能」权限用于：
+            · 单击浮窗时切换到对应的具体源窗口
+            · 增强模式的 fn 组合热键与悬停快捷键（= - F D fn ⌫）
 
             请在「系统设置 → 隐私与安全性 → 辅助功能」中勾选 MyWindowPip。
 
-            不开启增强模式也能正常使用：默认热键为 ⌃⌥P，浮窗操作可用悬浮按钮与右键菜单。
+            未授权时仍可正常捕获；单击浮窗只能激活源应用，由应用决定显示哪个窗口。
             """,
             """
-            Enhanced mode enables fn-based hotkeys and hover keyboard shortcuts (= - F D fn ⌫).
+            Accessibility is used to:
+            · Switch to the exact source window when a PiP is clicked
+            · Enable fn-based hotkeys and hover shortcuts (= - F D fn ⌫) in Enhanced mode
 
             Enable MyWindowPip in System Settings → Privacy & Security → Accessibility.
 
-            The app works fine without it: the default hotkey is ⌃⌥P and every action is available \
-            from the overlay buttons and right-click menu.
+            Capture still works without it; clicking a PiP can only activate the source application, \
+            which then chooses which window to show.
             """
         )
         alert.addButton(withTitle: L.t("打开系统设置", "Open System Settings"))

--- a/Sources/my-window-pip/PiPSession.swift
+++ b/Sources/my-window-pip/PiPSession.swift
@@ -1,5 +1,4 @@
 import AppKit
-import ApplicationServices
 import CoreMedia
 import ScreenCaptureKit
 
@@ -34,6 +33,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     private var probeTimer: Timer?
     private var hiddenAutoCloseTimer: Timer?
     private var occlusionObserver: NSObjectProtocol?
+    private var didExplainApplicationOnlyActivation = false
     private var isClosed = false
 
     private static let hiddenAutoCloseSeconds: TimeInterval = 60
@@ -102,6 +102,20 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     func bringToFront() { windowController.bringToFront() }
     func flashHighlight() { windowController.flashHighlight() }
+
+    /// ScreenCaptureKit 帧不携带窗口元数据；由 `SessionStore` 的共享低频刷新更新可变标题，
+    /// `CGWindowID` 身份保持不变。
+    func refreshSourceTitle(_ title: String) {
+        guard !isClosed,
+              case let .window(windowID, bundleID, appName, oldTitle) = state.source else { return }
+        let refreshed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !refreshed.isEmpty, refreshed != oldTitle else { return }
+        state.source = .window(
+            id: windowID, bundleID: bundleID, appName: appName, title: refreshed
+        )
+        windowController.setTitle(state.source.displayTitle)
+        Log.debug("源窗口标题已更新：\(state.source.displayTitle)")
+    }
 
     /// 仅用于 `--smoke` 集成自检的调试信息
     var debugWindowFrame: CGRect { windowController.window.frame }
@@ -625,7 +639,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         Preferences.shared.clickToActivateSource.toggle()
         let on = Preferences.shared.clickToActivateSource
         windowController.showHint(
-            on ? L.t("单击浮窗将切换到源应用", "Click the PiP to switch to the source app")
+            on ? L.t("单击浮窗将切换到源窗口", "Click the PiP to switch to the source window")
                : L.t("已关闭「单击回源」", "Click-to-switch is off"),
             near: nil, duration: 2.0
         )
@@ -636,8 +650,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     /// 单击浮窗 → 切换到源应用窗口。
     ///
-    /// 零权限路径只能激活「应用」；已授予辅助功能权限时再用 AX 把**那个具体窗口**抬到最前
-    /// （只读 `AXIsProcessTrusted()`，未授权直接跳过，绝不弹权限框）。
+    /// 零权限路径只能激活「应用」；已授予辅助功能权限时按 `CGWindowID` 把具体窗口抬到最前。
     func activateSource() {
         guard !isClosed else { return }
         guard Preferences.shared.clickToActivateSource else {
@@ -649,20 +662,49 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         case let .window(windowID, bundleID, appName, title):
             var pid = ShareableContentStore.shared.cachedWindow(id: windowID)?
                 .owningApplication?.processID
+                ?? SourceWindowActivator.ownerPID(of: windowID)
             if pid == nil, let bundleID, !bundleID.isEmpty {
                 pid = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
                     .first?.processIdentifier
             }
-            guard let pid, let app = NSRunningApplication(processIdentifier: pid) else {
+            guard let pid else {
                 windowController.showHint(
                     L.t("源应用似乎已退出", "The source app seems to have quit"),
                     near: nil, duration: 2.0
                 )
                 return
             }
-            _ = app.activate()
-            raiseWindowViaAccessibility(pid: pid, title: title)
-            Log.debug("单击回源：\(appName)")
+            switch SourceWindowActivator.activate(
+                windowID: windowID, pid: pid, fallbackTitle: title
+            ) {
+            case .raised:
+                Log.debug("单击回源：\(appName) [windowID=\(windowID)]")
+            case .applicationOnly:
+                if !didExplainApplicationOnlyActivation {
+                    didExplainApplicationOnlyActivation = true
+                    windowController.showHint(
+                        L.t("授予辅助功能权限后可精确切换到这个窗口",
+                            "Grant Accessibility to switch to this exact window"),
+                        near: nil, duration: 3.0
+                    )
+                }
+            case .windowNotFound:
+                windowController.showHint(
+                    L.t("无法定位对应的源窗口", "Could not locate the matching source window"),
+                    near: nil, duration: 2.0
+                )
+                Log.warn("单击回源未找到 AX 窗口：\(appName) [windowID=\(windowID)]")
+            case .activationFailed:
+                windowController.showHint(
+                    L.t("无法切换到源窗口", "Could not activate the source window"),
+                    near: nil, duration: 2.0
+                )
+            case .applicationNotFound:
+                windowController.showHint(
+                    L.t("源应用似乎已退出", "The source app seems to have quit"),
+                    near: nil, duration: 2.0
+                )
+            }
 
         case .region:
             windowController.showHint(
@@ -671,26 +713,6 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
                 near: nil, duration: 2.0
             )
         }
-    }
-
-    private func raiseWindowViaAccessibility(pid: pid_t, title: String) {
-        guard Permissions.hasAccessibility else { return }
-        let app = AXUIElementCreateApplication(pid)
-        var raw: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &raw) == .success,
-              let windows = raw as? [AXUIElement], !windows.isEmpty else { return }
-
-        let wanted = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        let target = windows.first { window in
-            var titleRef: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString,
-                                                &titleRef) == .success,
-                  let text = titleRef as? String else { return false }
-            return text == wanted
-        } ?? windows[0]
-
-        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
-        AXUIElementSetAttributeValue(app, kAXFocusedWindowAttribute as CFString, target)
     }
 
     func pipDidMove() {

--- a/Sources/my-window-pip/PiPWindowController.swift
+++ b/Sources/my-window-pip/PiPWindowController.swift
@@ -894,7 +894,7 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
         contextMenu.addItem(idleItem)
 
         // 单击回源开关（全局偏好，勾选态在 refreshMenu 里刷新）
-        clickActivateItem.title = L.t("单击浮窗切换到源应用", "Click to switch to source app")
+        clickActivateItem.title = L.t("单击浮窗切换到源窗口", "Click to switch to source window")
         clickActivateItem.target = self
         clickActivateItem.action = #selector(menuToggleClickToActivate)
         contextMenu.addItem(clickActivateItem)

--- a/Sources/my-window-pip/SelfTest.swift
+++ b/Sources/my-window-pip/SelfTest.swift
@@ -21,7 +21,7 @@ enum SelfTest {
             "\(Int($0.frame.width))×\(Int($0.frame.height))@\($0.backingScaleFactor)x"
         }.joined(separator: ", "))
         print("屏幕录制权限：\(Permissions.hasScreenRecording ? "已授权" : "未授权")")
-        print("辅助功能权限：\(Permissions.hasAccessibility ? "已授权" : "未授权（增强模式不可用）")")
+        print("辅助功能权限：\(Permissions.hasAccessibility ? "已授权" : "未授权（精确回源与增强模式不可用）")")
 
         guard Permissions.hasScreenRecording else {
             print("→ 缺少屏幕录制权限，无法验证捕获链路。")

--- a/Sources/my-window-pip/SessionStore.swift
+++ b/Sources/my-window-pip/SessionStore.swift
@@ -12,7 +12,11 @@ final class SessionStore {
     /// 软上限：超过后提示一次，用户确认可继续
     static let softLimit = 6
 
+    /// SCStream 帧只有像素、不含新标题；所有会话共用一次元数据刷新。
+    private static let metadataRefreshInterval: TimeInterval = 2.0
+
     private var screenObserver: NSObjectProtocol?
+    private var metadataRefreshTimer: Timer?
 
     private init() {
         screenObserver = NotificationCenter.default.addObserver(
@@ -172,11 +176,59 @@ final class SessionStore {
 
     private func add(_ session: PiPSession) {
         session.onClose = { [weak self] closed in
-            self?.sessions.removeAll { $0 === closed }
-            self?.onChange?()
+            guard let self else { return }
+            self.sessions.removeAll { $0 === closed }
+            self.updateMetadataRefreshTimer()
+            self.onChange?()
         }
         sessions.append(session)
+        updateMetadataRefreshTimer()
         onChange?()
+    }
+
+    private func updateMetadataRefreshTimer() {
+        let needsRefresh = sessions.contains { $0.sourceWindowID != nil }
+        guard needsRefresh else {
+            metadataRefreshTimer?.invalidate()
+            metadataRefreshTimer = nil
+            return
+        }
+        guard metadataRefreshTimer == nil else { return }
+
+        let timer = Timer(timeInterval: Self.metadataRefreshInterval, repeats: true) {
+            [weak self] _ in self?.refreshSourceTitles()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        metadataRefreshTimer = timer
+    }
+
+    private func refreshSourceTitles() {
+        let windowIDs = Set(sessions.compactMap(\.sourceWindowID))
+        guard !windowIDs.isEmpty,
+              let windows = CGWindowListCopyWindowInfo(.optionAll, kCGNullWindowID)
+                as? [[String: Any]] else { return }
+
+        var pids: [CGWindowID: pid_t] = [:]
+        var fallbackTitles: [CGWindowID: String] = [:]
+        for info in windows {
+            guard let number = info[kCGWindowNumber as String] as? NSNumber else { continue }
+            let windowID = CGWindowID(number.uint32Value)
+            guard windowIDs.contains(windowID) else { continue }
+            if let owner = info[kCGWindowOwnerPID as String] as? NSNumber {
+                pids[windowID] = pid_t(owner.int32Value)
+            }
+            if let title = info[kCGWindowName as String] as? String {
+                fallbackTitles[windowID] = title
+            }
+        }
+        for session in sessions {
+            guard let windowID = session.sourceWindowID else { continue }
+            let title = pids[windowID].flatMap {
+                SourceWindowActivator.currentTitle(of: windowID, pid: $0)
+            } ?? fallbackTitles[windowID]
+            guard let title else { continue }
+            session.refreshSourceTitle(title)
+        }
     }
 
     private func confirmIfOverLimit() -> Bool {

--- a/Sources/my-window-pip/SettingsWindowController.swift
+++ b/Sources/my-window-pip/SettingsWindowController.swift
@@ -302,7 +302,11 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     }
 
     @objc private func clickToActivateChanged(_ sender: NSButton) {
-        prefs.clickToActivateSource = sender.state == .on
+        let enabled = sender.state == .on
+        prefs.clickToActivateSource = enabled
+        if enabled, !Permissions.hasAccessibility {
+            Permissions.showAccessibilityGuide()
+        }
     }
 
     @objc private func launchAtLoginChanged(_ sender: NSButton) {

--- a/Sources/my-window-pip/SourceWindowActivator.swift
+++ b/Sources/my-window-pip/SourceWindowActivator.swift
@@ -1,0 +1,122 @@
+import AppKit
+import ApplicationServices
+import Darwin
+
+/// 激活 PiP 会话正在捕获的具体应用窗口。
+///
+/// Accessibility 提供窗口操作，却没有公开的 `CGWindowID` 属性。macOS 导出了
+/// `_AXUIElementGetWindow`，这里动态解析符号：系统不支持时安全失败，再退到「标题唯一」匹配。
+enum SourceWindowActivator {
+    enum Result {
+        case raised
+        case applicationOnly
+        case windowNotFound
+        case activationFailed
+        case applicationNotFound
+    }
+
+    private typealias GetWindowID = @convention(c) (
+        AXUIElement, UnsafeMutablePointer<CGWindowID>
+    ) -> AXError
+
+    private static let getWindowID: GetWindowID? = {
+        guard let handle = dlopen(nil, RTLD_LAZY),
+              let symbol = dlsym(handle, "_AXUIElementGetWindow") else { return nil }
+        return unsafeBitCast(symbol, to: GetWindowID.self)
+    }()
+
+    /// 源窗口位于其它 Space、已不在 ScreenCaptureKit 缓存时，用 CGWindowList 补取 PID。
+    static func ownerPID(of windowID: CGWindowID) -> pid_t? {
+        guard let list = CGWindowListCopyWindowInfo(.optionIncludingWindow, windowID)
+                as? [[String: Any]],
+              let info = list.first(where: {
+                  ($0[kCGWindowNumber as String] as? NSNumber)?.uint32Value == windowID
+              }),
+              let number = info[kCGWindowOwnerPID as String] as? NSNumber else { return nil }
+        return pid_t(number.int32Value)
+    }
+
+    static func activate(windowID: CGWindowID, pid: pid_t, fallbackTitle: String) -> Result {
+        guard let runningApp = NSRunningApplication(processIdentifier: pid) else {
+            return .applicationNotFound
+        }
+
+        // 没有辅助功能权限时，AppKit 只能激活应用，具体显示哪个窗口由应用自己决定。
+        guard Permissions.hasAccessibility else {
+            return runningApp.activate() ? .applicationOnly : .activationFailed
+        }
+
+        let app = AXUIElementCreateApplication(pid)
+        guard let windows = windows(of: app),
+              let target = exactWindow(id: windowID, in: windows)
+                ?? uniqueWindow(titled: fallbackTitle, in: windows) else {
+            _ = runningApp.activate()
+            return .windowNotFound
+        }
+
+        // 先恢复被最小化的源窗口。不同 App 对 AX 可写属性的支持不一，聚焦或抬起任一成功即算完成。
+        AXUIElementSetAttributeValue(target, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
+        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+        let firstFocus = AXUIElementSetAttributeValue(
+            app, kAXFocusedWindowAttribute as CFString, target
+        )
+        _ = runningApp.activate()
+        let raised = AXUIElementPerformAction(target, kAXRaiseAction as CFString)
+        let finalFocus = AXUIElementSetAttributeValue(
+            app, kAXFocusedWindowAttribute as CFString, target
+        )
+
+        if raised == .success || firstFocus == .success || finalFocus == .success {
+            return .raised
+        }
+        return .activationFailed
+    }
+
+    /// 读取指定窗口的实时 AX 标题。Electron 等应用的 CGWindowName 可能不会随文档切换及时更新。
+    static func currentTitle(of windowID: CGWindowID, pid: pid_t) -> String? {
+        guard Permissions.hasAccessibility else { return nil }
+        let app = AXUIElementCreateApplication(pid)
+        guard let windows = windows(of: app),
+              let target = exactWindow(id: windowID, in: windows) else { return nil }
+
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            target, kAXTitleAttribute as CFString, &raw
+        ) == .success else { return nil }
+        return raw as? String
+    }
+
+    private static func windows(of app: AXUIElement) -> [AXUIElement]? {
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            app, kAXWindowsAttribute as CFString, &raw
+        ) == .success else { return nil }
+        return raw as? [AXUIElement]
+    }
+
+    private static func exactWindow(id: CGWindowID, in windows: [AXUIElement]) -> AXUIElement? {
+        guard let getWindowID else { return nil }
+        return windows.first { window in
+            var candidate: CGWindowID = 0
+            return getWindowID(window, &candidate) == .success && candidate == id
+        }
+    }
+
+    /// 仅用于兼容性降级：标题为空或同名窗口不唯一时绝不猜测。
+    private static func uniqueWindow(
+        titled title: String, in windows: [AXUIElement]
+    ) -> AXUIElement? {
+        let wanted = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !wanted.isEmpty else { return nil }
+
+        let matches = windows.filter { window in
+            var raw: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+                window, kAXTitleAttribute as CFString, &raw
+            ) == .success,
+                  let candidate = raw as? String else { return false }
+            return candidate.trimmingCharacters(in: .whitespacesAndNewlines) == wanted
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+}


### PR DESCRIPTION
## Summary

- activate the exact window captured by each PiP session instead of whichever window the source app currently considers frontmost
- refresh mutable source-window titles every two seconds so the hover control bar follows document/file changes
- clarify that Accessibility is optional for capture, but required for exact source-window activation

## Root cause

Each PiP session already retained its source `CGWindowID`, but click-to-switch only activated the owning application and then tried to locate an Accessibility window by its title. Editors such as Cursor change the title whenever the active file changes, so the saved title quickly became stale. When title matching failed, the implementation selected `windows[0]`, which could raise a different project window.

ScreenCaptureKit frames also contain pixels rather than refreshed window metadata, so continuously receiving frames did not update the title shown in the PiP hover controls.

## Implementation

- add a small `SourceWindowActivator` bridge that maps Accessibility windows back to their `CGWindowID`
  - `_AXUIElementGetWindow` is resolved dynamically, avoiding a hard link and allowing a safe fallback when unavailable
  - the fallback accepts only a unique exact title match; it never guesses by selecting the first window
- restore, focus, and raise the matched source window through Accessibility
- retain application-only activation when Accessibility has not been granted and show a one-time explanatory hint
- share one metadata timer across all PiP sessions and stop it when no window sessions remain
- refresh titles from the exact window's AX title, with `CGWindowName` as a no-Accessibility fallback
- update permission guidance and bilingual documentation

## Validation

- manually tested three maximized Cursor project windows at identical positions and sizes
  - switched active files so all three window titles changed
  - verified each PiP click raises the matching project window
  - verified the hover control-bar title updates within the two-second refresh interval
- verified exact `CGWindowID` activation against a live source window
- `swiftc -typecheck` for both `arm64-apple-macos14.0` and `x86_64-apple-macos14.0`
- `--selftest` capture path passed with 10 valid frames
- three-session `--smoke` regression passed, including timer cleanup when sessions close
- `git diff --check`
