### PR TITLE
fix: keep PiP windows below system menus

### DIFF
--- a/Sources/my-window-pip/Models.swift
+++ b/Sources/my-window-pip/Models.swift
@@ -67,31 +67,44 @@ enum FPSStep: Int, CaseIterable {
     }
 }
 
-/// 浮窗层级偏好。
+/// 浮窗在窗口层级、Spaces 与全屏环境中的展示方式。
+///
+/// 窗口层级与 Space 行为是两组独立能力：常规的全局悬浮只需要 `.floating`
+/// 配合 collection behavior；`.screenSaver` 仅留给明确选择「强制最顶层」的用户，
+/// 避免默认压住菜单栏下拉菜单、系统提示和模态面板。
 enum WindowLevelMode: String, CaseIterable {
-    /// 全局悬浮：所有 Space 可见，尽量盖在全屏应用之上。
+    /// 推荐模式：所有 Space / 全屏空间可见，但系统菜单仍能正常显示在浮窗之上。
     case global
-    /// 普通置顶：仅当前 Space，不侵入全屏应用。
+    /// 仅跟随当前 Space，仍置于该 Space 的普通窗口之上。
     case normal
+    /// 兼容少数会压住普通浮动面板的全屏应用；代价是可能遮挡系统级菜单。
+    case topmost
 
     var windowLevel: NSWindow.Level {
         switch self {
-        case .global: return .screenSaver
-        case .normal: return .floating
+        case .global, .normal: return .floating
+        case .topmost: return .screenSaver
         }
     }
 
     var collectionBehavior: NSWindow.CollectionBehavior {
         switch self {
-        case .global: return [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
+        case .global, .topmost:
+            return [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
         case .normal: return [.managed, .fullScreenAuxiliary]
         }
     }
 
     var label: String {
         switch self {
-        case .global: return L.t("全局悬浮（所有 Space / 全屏应用之上）", "Global (all Spaces, above full-screen)")
-        case .normal: return L.t("普通置顶（仅当前 Space）", "Normal (current Space only)")
+        case .global:
+            return L.t("全局悬浮（推荐，系统菜单优先）",
+                       "Global (recommended, below system menus)")
+        case .normal:
+            return L.t("当前 Space 置顶", "Current Space only")
+        case .topmost:
+            return L.t("强制最顶层（可能遮挡系统菜单）",
+                       "Force topmost (may cover system menus)")
         }
     }
 }

--- a/Sources/my-window-pip/OverlayControlsView.swift
+++ b/Sources/my-window-pip/OverlayControlsView.swift
@@ -8,8 +8,8 @@ import AppKit
 /// - 显示/隐藏统一走 `setVisible(_:animated:)`；淡出结束后置 `isHidden = true`，彻底不拦截鼠标。
 /// - 本视图只发信号（闭包回调），不持有会话、不改状态；状态一律由 `update(state:)` 单向灌入。
 ///
-/// 提示语约定（v0.1.2）：**不再使用系统 tooltip**。浮窗 level 是 `.screenSaver`(1000)，
-/// 系统 tooltip 是独立窗口且层级更低，会被压在浮窗后面只露出一小部分，初始延迟也无公开 API 可调。
+/// 提示语约定（v0.1.2）：**不再使用系统 tooltip**。强制最顶层模式使用 `.screenSaver`，
+/// 系统 tooltip 会被压在浮窗后面；它的初始延迟也无公开 API 可调。
 /// 因此这里只负责「鼠标进入了哪个控件、该显示什么文案」，连同该控件的**屏幕坐标 frame** 经
 /// `onHintChange` 零延迟上抛，由 `PiPWindowController` 用跟随浮窗的子窗口画在图标上方。
 /// 无障碍标签（`setAccessibilityLabel`）全部保留。

--- a/Sources/my-window-pip/PiPWindowController.swift
+++ b/Sources/my-window-pip/PiPWindowController.swift
@@ -64,8 +64,8 @@ private final class PiPRootView: NSView {
 
 /// 提示条内容视图（自绘背景 + 文字），由 `PiPWindowController` 放进一个跟随浮窗的子窗口里。
 ///
-/// 为什么不用系统 tooltip：浮窗 level 为 `.screenSaver`(1000)，而系统 tooltip 是层级更低的独立窗口，
-/// 会被压在浮窗后面只露出窗外的一小截；它的初始延迟也由 `NSToolTipManager` 私有控制，无法调整。
+/// 为什么不用系统 tooltip：强制最顶层模式使用 `.screenSaver`，系统 tooltip 会被压在浮窗后面；
+/// 此外它的初始延迟由 `NSToolTipManager` 私有控制，无法满足控制条的即时反馈。
 ///
 /// 为什么不用 `NSTextField`：`NSTextField` 的 cell 自身还有约 2pt 的左右内边距，
 /// 按 `NSString.size(withAttributes:)` 算出的宽度总会比 cell 实际需要的少 4pt 左右，
@@ -510,7 +510,7 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
 
     // MARK: - 提示条（跟随浮窗的子窗口）
 
-    /// 在浮窗外显示提示条（不用系统 tooltip，避免被浮窗层级遮挡）。
+    /// 在浮窗外显示提示条（不用系统 tooltip，兼容强制最顶层模式并提供即时反馈）。
     ///
     /// - Parameters:
     ///   - text: nil / 空串表示立即隐藏提示
@@ -899,7 +899,7 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
         clickActivateItem.action = #selector(menuToggleClickToActivate)
         contextMenu.addItem(clickActivateItem)
 
-        let levelItem = NSMenuItem(title: L.t("置顶层级", "Window Level"), action: nil, keyEquivalent: "")
+        let levelItem = NSMenuItem(title: L.t("悬浮方式", "PiP Behavior"), action: nil, keyEquivalent: "")
         let levelMenu = NSMenu()
         levelMenu.autoenablesItems = false
         for mode in WindowLevelMode.allCases {

--- a/Sources/my-window-pip/SettingsWindowController.swift
+++ b/Sources/my-window-pip/SettingsWindowController.swift
@@ -5,7 +5,7 @@ import AppKit
 final class SettingsWindowController: NSObject, NSWindowDelegate {
     static let shared = SettingsWindowController()
 
-    /// 浮窗层级变化后需要应用到已打开的浮窗
+    /// 浮窗展示方式变化后需要应用到已打开的浮窗
     var onLevelModeChanged: ((WindowLevelMode) -> Void)?
     /// 自动隐藏透明度变化后需要应用到已打开的浮窗
     var onAutoHideOpacityChanged: ((CGFloat) -> Void)?
@@ -80,7 +80,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         levelPopup.selectItem(at: WindowLevelMode.allCases.firstIndex(of: prefs.windowLevelMode) ?? 0)
         levelPopup.target = self
         levelPopup.action = #selector(levelModeChanged(_:))
-        stack.addArrangedSubview(row(L.t("浮窗层级", "Window level"), levelPopup))
+        stack.addArrangedSubview(row(L.t("悬浮方式", "PiP behavior"), levelPopup))
 
         stack.addArrangedSubview(checkbox(
             L.t("新建浮窗默认开启自动隐藏（鼠标移上去淡出并可点透）",

--- a/Sources/my-window-pip/UpdateProgressWindow.swift
+++ b/Sources/my-window-pip/UpdateProgressWindow.swift
@@ -25,7 +25,7 @@ private enum UpdateProgressMetrics {
 ///
 /// 几个刻意的设计选择：
 /// - `NSPanel` + `.nonactivatingPanel`：不抢当前 App 的焦点（本应用是 `LSUIElement`，没有主窗口）
-/// - `level = .floating`：**必须低于 PiP 浮窗的 `.screenSaver`**，否则会盖住画中画
+/// - `level = .normal`：低于所有 PiP 模式，下载反馈可见但不会反过来盖住画中画
 /// - 单例复用：重复 `show` 只把已有面板前置，不重建窗口；`dismiss` 只 `orderOut`，实例留着下次用
 /// - 所有对外方法内部都会兜一层主线程派发，调用方可以直接从 URLSession 的 delegate 队列调用
 final class UpdateProgressWindow: NSObject, NSWindowDelegate {
@@ -206,9 +206,9 @@ final class UpdateProgressWindow: NSObject, NSWindowDelegate {
 
     private func configurePanel() {
         panel.title = L.t("软件更新", "Software Update")
-        // 低于 PiP 浮窗的 .screenSaver，绝不盖住画中画
-        panel.level = .floating
         panel.isFloatingPanel = true
+        // isFloatingPanel 之后显式设回 normal：保留非激活面板行为，但始终低于 PiP 的 floating 层级
+        panel.level = .normal
         panel.becomesKeyOnlyIfNeeded = true      // 不抢焦点，点按钮也不需要成为 key window
         panel.hidesOnDeactivate = false          // 切到别的 App 时进度依然可见
         panel.isReleasedWhenClosed = false       // 单例复用，关闭不销毁

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -32,7 +32,8 @@ App 层    main.swift · AppDelegate · StatusBarController · SettingsWindowCon
 - **不跨帧持有 `CMSampleBuffer`**，`queueDepth = 3`，宁丢帧不积压。
 - **防镜中镜**：浮窗 `sharingType = .none`；窗口枚举过滤自身 App；区域捕获的显示器过滤器按 App 排除自己。
 - **零权限优先**：任何功能都必须能在「只有屏幕录制权限」的前提下通过控制条或右键菜单完成；辅助功能权限只允许作为增强项。
-- **不用系统 tooltip**：浮窗 level 是 `.screenSaver`(1000)，系统 tooltip 窗口层级更低会被压在浮窗后面，而且初始延迟不可调。所有浮窗内的提示统一走 `PiPWindowController.showHint(_:near:duration:)`，它用一个 `addChildWindow` 挂在浮窗上的**子窗口**承载（这样才能画到浮窗顶边之外、显示在图标上方），子窗口必须 `ignoresMouseEvents = true`。新增按钮时把提示文案登记到 `OverlayControlsView` 的 hint 映射里，不要再写 `toolTip`。
+- **窗口层级与 Space 行为分离**：默认「全局悬浮」使用 `.floating`，通过 `.canJoinAllSpaces` + `.fullScreenAuxiliary` 实现所有 Space / 全屏可见，让系统菜单、提示与模态窗口保持在 PiP 上方；`.screenSaver` 只用于用户显式选择的「强制最顶层」兼容模式。
+- **不用系统 tooltip**：强制最顶层模式会压住系统 tooltip，而且系统 tooltip 的初始延迟不可调。所有浮窗内的提示统一走 `PiPWindowController.showHint(_:near:duration:)`，它用一个 `addChildWindow` 挂在浮窗上的**子窗口**承载（这样才能画到浮窗顶边之外、显示在图标上方），子窗口必须 `ignoresMouseEvents = true`。新增按钮时把提示文案登记到 `OverlayControlsView` 的 hint 映射里，不要再写 `toolTip`。
 - **拖动是手动实现的**：`isMovableByWindowBackground = false`，由 `PiPContentView` 在 `mouseDragged` 里按位移 `setFrameOrigin`。原因是系统背景拖动会吞掉 `mouseUp`，拿不到干净的单击，而单击要用来「切回源应用」。改动手势时注意保持「拖动后触发 `pipDidMove` 持久化」与「跨屏 scale 变化后 retune」两条链路。
 - **自动隐藏必须留逃生通道**：淡出后浮窗 `ignoresMouseEvents = true`，收不到任何鼠标事件。通道有四条：鼠标停在顶栏热区（`HoverMonitor` 的 `hotZoneProvider` + `PiPWindowController.barScreenFrame`）、按住 ⌥ 临时唤回、菜单栏每会话子菜单、开启时的 3 秒提示。改动自动隐藏逻辑时这几条不能破。
 - **双语**：用户可见字符串一律 `L.t("中文", "English")`，不引入 `.lproj`。


### PR DESCRIPTION
## Summary

- use the standard `.floating` level for the recommended global PiP mode while preserving all-Spaces and full-screen collection behavior
- retain the previous `.screenSaver` behavior as an explicit “Force topmost” compatibility mode with a clear system-menu warning
- keep the current-Space mode and update settings/context-menu labels to describe behavior rather than only the raw window level
- place the software-update progress panel at `.normal` so it remains below every PiP mode
- update the window-level and tooltip implementation notes

## Root cause

The global PiP mode used `.screenSaver`, whose WindowServer level is above status-bar pop-up menus. A PiP positioned below the menu bar could therefore cover menus opened from menu-bar utilities.

Window level and Space behavior are independent AppKit concepts. The recommended mode can remain visible across Spaces and alongside full-screen apps through `.canJoinAllSpaces` and `.fullScreenAuxiliary` without using the screen-saver level.

## Compatibility and impact

Existing `global` and `normal` preference raw values remain valid. Existing `global` users automatically receive the system-friendly behavior, while users who require the legacy strongest level can explicitly select “Force topmost.”

## Validation

- `git diff --check`
- `swift build`
- `swift build -c release`
- `bash scripts/build-app.sh --fast --debug`
- verified the AppKit level ordering at runtime: `normal(0) < floating(3) < modal(8) < mainMenu(24) < status(25) < popUpMenu(101) < screenSaver(1000)`
- verified at runtime that `isFloatingPanel` raises a panel to `.floating`, and an explicit `.normal` assignment restores level 0

The app bundle build completed successfully. The local release signing identity was unavailable, so the validation bundle used the build script’s documented ad-hoc fallback.
