### PR TITLE
fix: remember PiP positions per capture target

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Built on the system [ScreenCaptureKit](https://developer.apple.com/documentation
 **Picture-in-Picture**
 - Turn the frontmost window into a PiP with one hotkey (`⌃⌥P`), or pick a window from the menu bar list.
 - Capture any screen region (`⌃⌥⇧P`); if the selection lands inside a window, a window stream is used instead, so it follows the window and keeps working when the window is covered.
-- Multiple PiP windows at once, cascaded automatically; position and width remembered per app.
+- Multiple PiP windows at once, cascaded automatically; each source window or captured region remembers its own position, while width remains app-level.
 - Floating, borderless, aspect-locked, visible on all Spaces and above full-screen apps — but below system pop-up menus, so menu bar utilities still open on top of it.
 
 **Zoom & pan**
@@ -202,7 +202,7 @@ verifies the signature and publishes a GitHub Release — the release path delib
 **画中画**
 - 一键把前台窗口变浮窗（`⌃⌥P`），或从菜单栏窗口列表里挑。
 - 框选任意屏幕区域做画中画（`⌃⌥⇧P`）；选区落在某个窗口内时自动改用窗口流，可跟随窗口移动、被遮挡也能捕获。
-- 多个浮窗同时运行，自动错位摆放，位置与宽度按应用记忆。
+- 多个浮窗同时运行，自动错位摆放；每个源窗口或捕获区域分别记忆位置，宽度仍按应用记忆。
 - 浮窗置顶、可在所有 Space 与全屏应用之上显示、无边框、锁定宽高比；但层级低于系统下拉菜单，浮窗放右上角也不会挡住菜单栏工具的菜单。
 
 **缩放与平移**

--- a/Sources/my-window-pip/Models.swift
+++ b/Sources/my-window-pip/Models.swift
@@ -11,7 +11,7 @@ enum CaptureSource: Equatable {
     /// 屏幕区域。`rect` 为 AppKit 全局坐标（左下原点，逻辑点）。
     case region(displayID: CGDirectDisplayID, rect: CGRect)
 
-    /// per-app 偏好（帧率/宽度/位置）使用的存储键。
+    /// per-app 偏好（帧率/宽度，以及位置的应用级回退）使用的存储键。
     var preferenceKey: String {
         switch self {
         case let .window(_, bundleID, appName, _): return bundleID ?? "app:\(appName)"
@@ -44,6 +44,66 @@ enum CaptureSource: Equatable {
     var displayTitle: String {
         let t = title
         return t.isEmpty ? appName : "\(appName) · \(t)"
+    }
+}
+
+// MARK: - 位置记忆身份
+
+/// 一个 PiP 捕获目标的位置记忆身份。
+///
+/// 标题不稳定，不能参与身份。整窗使用 `CGWindowID`；区域捕获额外包含量化后的捕获矩形，
+/// 从而让同一源窗口里的多个裁剪区域、以及多个显示器区域分别记住自己的位置。
+enum PositionMemoryIdentity: Equatable {
+    case window(appPreferenceKey: String, windowID: CGWindowID)
+    case windowRegion(appPreferenceKey: String, windowID: CGWindowID, rect: CGRect)
+    case displayRegion(displayID: CGDirectDisplayID, rect: CGRect)
+
+    /// 沿用首版窗口级位置键前缀，避免开发版本之间丢失已经记住的整窗位置。
+    static let specificPreferencePrefix = "__window_position__:"
+
+    var preferenceKey: String {
+        switch self {
+        case let .window(appKey, windowID):
+            return "\(Self.specificPreferencePrefix)\(appKey):\(windowID)"
+        case let .windowRegion(appKey, windowID, rect):
+            return "\(Self.specificPreferencePrefix)region:\(appKey):\(windowID):\(Self.rectKey(rect))"
+        case let .displayRegion(displayID, rect):
+            return "\(Self.specificPreferencePrefix)display:\(displayID):\(Self.rectKey(rect))"
+        }
+    }
+
+    /// 没有精确记录时使用的旧版兼容回退，也是判断是否已有同类活跃会话的命名空间。
+    var fallbackPreferenceKey: String {
+        switch self {
+        case let .window(appKey, _), let .windowRegion(appKey, _, _): return appKey
+        case .displayRegion: return CaptureSource.regionPreferenceKey
+        }
+    }
+
+    /// 源应用重启并匹配到新窗口后，只替换窗口实例身份；区域几何保持不变。
+    func retargetingWindow(to source: CaptureSource) -> PositionMemoryIdentity {
+        guard case let .window(windowID, _, _, _) = source else { return self }
+        switch self {
+        case .window:
+            return .window(appPreferenceKey: source.preferenceKey, windowID: windowID)
+        case let .windowRegion(_, _, rect):
+            return .windowRegion(
+                appPreferenceKey: source.preferenceKey, windowID: windowID, rect: rect
+            )
+        case .displayRegion:
+            return self
+        }
+    }
+
+    static func isSpecificPreferenceKey(_ key: String) -> Bool {
+        key.hasPrefix(specificPreferencePrefix)
+    }
+
+    /// 选区最终会 integral，但窗口坐标仍可能带小数；量化到 1/16pt 可消除无意义的浮点抖动。
+    private static func rectKey(_ rect: CGRect) -> String {
+        [rect.minX, rect.minY, rect.width, rect.height]
+            .map { String(Int(($0 * 16).rounded())) }
+            .joined(separator: ",")
     }
 }
 
@@ -122,6 +182,7 @@ struct PiPSessionState {
 /// 创建一个 PiP 会话的请求。
 struct SessionRequest {
     var source: CaptureSource
+    var positionIdentity: PositionMemoryIdentity
     /// 捕获基准矩形（源坐标系、左上原点、逻辑点）：
     /// - 整窗 PiP：`(0, 0, 窗口宽, 窗口高)`
     /// - 窗口内的区域捕获：该区域在窗口内的局部矩形

--- a/Sources/my-window-pip/PiPSession.swift
+++ b/Sources/my-window-pip/PiPSession.swift
@@ -13,6 +13,8 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     /// 捕获基准矩形（源坐标系、左上原点、逻辑点），缩放平移都在其内部进行
     private var baseRect: CGRect
     private var sourcePixelSize: CGSize
+    /// 与显示标题解耦的位置身份；窗口重匹配时只更新其中的 CGWindowID。
+    private var positionIdentity: PositionMemoryIdentity
 
     private let engine = CaptureEngine()
     private let windowController: PiPWindowController
@@ -55,7 +57,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     // MARK: - 生命周期
 
-    init(request: SessionRequest, cascadeIndex: Int) {
+    init(request: SessionRequest, initialOrigin: CGPoint?, cascadeIndex: Int) {
         state = PiPSessionState(
             source: request.source,
             fps: request.fps,
@@ -64,6 +66,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         )
         baseRect = request.baseSourceRect
         sourcePixelSize = request.sourcePixelSize
+        positionIdentity = request.positionIdentity
         idleDetector = IdleDetector()
 
         let prefs = Preferences.shared
@@ -73,7 +76,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
             title: request.source.displayTitle,
             aspect: request.sourcePointSize,
             initialWidth: width,
-            origin: prefs.origin(for: request.source.preferenceKey),
+            origin: initialOrigin,
             levelMode: prefs.windowLevelMode,
             cascadeIndex: cascadeIndex
         )
@@ -115,6 +118,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     // MARK: - 对外操作
 
     var sourceWindowID: CGWindowID? { state.source.windowID }
+    var positionFallbackPreferenceKey: String { positionIdentity.fallbackPreferenceKey }
     var title: String { state.source.displayTitle }
     var isHidden: Bool { state.isHidden }
     var isPaused: Bool { state.isPaused }
@@ -603,7 +607,9 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
                 return
             }
             Log.info("已重新匹配到源窗口：\(ShareableContentStore.shared.displayTitle(for: window))")
-            self.state.source = ShareableContentStore.shared.captureSource(for: window)
+            let rematchedSource = ShareableContentStore.shared.captureSource(for: window)
+            self.state.source = rematchedSource
+            self.positionIdentity = self.positionIdentity.retargetingWindow(to: rematchedSource)
             // 重新匹配同样不能照抄可能被总览变换过的尺寸
             let size = self.trustedSize(of: window) ?? self.baseRect.size
             self.baseRect = CGRect(origin: .zero, size: size)
@@ -763,9 +769,14 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     }
 
     private func persistGeometry() {
-        let key = state.source.preferenceKey
-        Preferences.shared.setPreferredWidth(windowController.contentPointSize.width, for: key)
-        Preferences.shared.setOrigin(windowController.frameOrigin, for: key)
+        Preferences.shared.setPreferredWidth(
+            windowController.contentPointSize.width, for: state.source.preferenceKey
+        )
+        persistOrigin()
+    }
+
+    private func persistOrigin() {
+        Preferences.shared.setOrigin(windowController.frameOrigin, for: positionIdentity)
     }
 
     // MARK: - PiPWindowDelegate
@@ -914,6 +925,6 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     func pipMenuWillOpen() { refreshSourceTitleNow() }
 
     func pipDidMove() {
-        Preferences.shared.setOrigin(windowController.frameOrigin, for: state.source.preferenceKey)
+        persistOrigin()
     }
 }

--- a/Sources/my-window-pip/Preferences.swift
+++ b/Sources/my-window-pip/Preferences.swift
@@ -78,13 +78,17 @@ enum KeyCodeNames {
 
 /// UserDefaults 封装。所有偏好读写唯一入口。
 final class Preferences {
-    static let shared = Preferences()
-    private let d = UserDefaults.standard
+    static let shared = Preferences(defaults: .standard)
+    private let d: UserDefaults
+    private let now: () -> TimeInterval
 
     private enum K {
         static let fpsByApp = "fpsByApp"
         static let widthByApp = "widthByApp"
+        // 历史键名沿用以兼容旧版本；现在同时保存回退位置与捕获目标的精确位置。
         static let originByApp = "originByApp"
+        // 同样沿用首版开发键名；实际覆盖整窗和区域捕获的精确位置。
+        static let windowOriginLastUsed = "windowOriginLastUsed"
         static let hotkeyPiP = "hotkey.pip"
         static let hotkeyRegion = "hotkey.region"
         static let hotkeyCloseAll = "hotkey.closeAll"
@@ -100,7 +104,11 @@ final class Preferences {
         static let clickToActivateSource = "clickToActivateSource"
     }
 
-    private init() {
+    /// 注入 defaults 与时钟，生产环境使用标准域；测试使用独立 suite，避免污染用户偏好。
+    init(defaults: UserDefaults = .standard,
+         now: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {
+        d = defaults
+        self.now = now
         d.register(defaults: [
             K.defaultFPS: FPSStep.fifteen.rawValue,
             K.autoHideDefault: false,
@@ -256,16 +264,59 @@ final class Preferences {
         d.set(dict, forKey: K.widthByApp)
     }
 
-    func origin(for prefKey: String) -> CGPoint? {
+    func origin(for identity: PositionMemoryIdentity) -> CGPoint? {
+        storedOrigin(for: identity.preferenceKey, touch: true)
+    }
+
+    func fallbackOrigin(for identity: PositionMemoryIdentity) -> CGPoint? {
+        storedOrigin(for: identity.fallbackPreferenceKey, touch: false)
+    }
+
+    private func storedOrigin(for prefKey: String, touch: Bool) -> CGPoint? {
         guard let dict = d.dictionary(forKey: K.originByApp) as? [String: [Double]],
               let v = dict[prefKey], v.count == 2 else { return nil }
+        if touch { touchPositionOriginIfNeeded(prefKey) }
         return CGPoint(x: v[0], y: v[1])
     }
 
-    func setOrigin(_ origin: CGPoint, for prefKey: String) {
+    /// 一次读改写同时保存精确位置和旧版兼容回退，避免两个独立写入之间留下半更新状态。
+    func setOrigin(_ origin: CGPoint, for identity: PositionMemoryIdentity) {
         var dict = (d.dictionary(forKey: K.originByApp) as? [String: [Double]]) ?? [:]
-        dict[prefKey] = [Double(origin.x), Double(origin.y)]
+        let value = [Double(origin.x), Double(origin.y)]
+        dict[identity.preferenceKey] = value
+        dict[identity.fallbackPreferenceKey] = value
+        if PositionMemoryIdentity.isSpecificPreferenceKey(identity.preferenceKey) {
+            var lastUsed = (d.dictionary(forKey: K.windowOriginLastUsed) as? [String: Double]) ?? [:]
+            lastUsed[identity.preferenceKey] = now()
+            prunePositionOrigins(&dict, lastUsed: &lastUsed)
+            d.set(lastUsed, forKey: K.windowOriginLastUsed)
+        }
         d.set(dict, forKey: K.originByApp)
+    }
+
+    /// 捕获目标可能不断变化；只保留最近使用的记录，避免长期使用后 UserDefaults 膨胀。
+    private static let maxRememberedPositionOrigins = 128
+
+    private func touchPositionOriginIfNeeded(_ key: String) {
+        guard PositionMemoryIdentity.isSpecificPreferenceKey(key) else { return }
+        var lastUsed = (d.dictionary(forKey: K.windowOriginLastUsed) as? [String: Double]) ?? [:]
+        lastUsed[key] = now()
+        d.set(lastUsed, forKey: K.windowOriginLastUsed)
+    }
+
+    private func prunePositionOrigins(_ origins: inout [String: [Double]],
+                                      lastUsed: inout [String: Double]) {
+        let positionKeys = origins.keys.filter {
+            PositionMemoryIdentity.isSpecificPreferenceKey($0)
+        }
+        guard positionKeys.count > Self.maxRememberedPositionOrigins else { return }
+        let stale = positionKeys.sorted {
+            (lastUsed[$0] ?? 0) < (lastUsed[$1] ?? 0)
+        }.prefix(positionKeys.count - Self.maxRememberedPositionOrigins)
+        for key in stale {
+            origins.removeValue(forKey: key)
+            lastUsed.removeValue(forKey: key)
+        }
     }
 
     /// 终端/日志/编辑器类应用的关键字，命中则首次默认 5 fps。

--- a/Sources/my-window-pip/SessionStore.swift
+++ b/Sources/my-window-pip/SessionStore.swift
@@ -74,9 +74,13 @@ final class SessionStore {
         let source = store.captureSource(for: window)
         let size = window.frame.size
         guard size.width > 1, size.height > 1 else { return }
+        let positionIdentity = PositionMemoryIdentity.window(
+            appPreferenceKey: source.preferenceKey, windowID: window.windowID
+        )
 
         let request = SessionRequest(
             source: source,
+            positionIdentity: positionIdentity,
             baseSourceRect: CGRect(origin: .zero, size: size),
             sourcePixelSize: store.pixelSize(of: window),
             sourcePointSize: size,
@@ -84,7 +88,11 @@ final class SessionStore {
             autoHide: Preferences.shared.autoHideDefault,
             idleDetection: Preferences.shared.idleDetectionDefault
         )
-        add(PiPSession(request: request, cascadeIndex: sessions.count))
+        add(PiPSession(
+            request: request,
+            initialOrigin: initialOrigin(for: positionIdentity),
+            cascadeIndex: sessions.count
+        ))
         Log.info("新建窗口 PiP：\(source.displayTitle) @ \(request.fps.label)")
     }
 
@@ -114,8 +122,12 @@ final class SessionStore {
             ).intersection(CGRect(origin: .zero, size: frameTopLeft.size))
             if local.width >= 40, local.height >= 40 {
                 let source = store.captureSource(for: window)
+                let positionIdentity = PositionMemoryIdentity.windowRegion(
+                    appPreferenceKey: source.preferenceKey, windowID: window.windowID, rect: local
+                )
                 let request = SessionRequest(
                     source: source,
+                    positionIdentity: positionIdentity,
                     baseSourceRect: local,
                     sourcePixelSize: CGSize(width: local.width * scale, height: local.height * scale),
                     sourcePointSize: local.size,
@@ -123,7 +135,11 @@ final class SessionStore {
                     autoHide: Preferences.shared.autoHideDefault,
                     idleDetection: Preferences.shared.idleDetectionDefault
                 )
-                add(PiPSession(request: request, cascadeIndex: sessions.count))
+                add(PiPSession(
+                    request: request,
+                    initialOrigin: initialOrigin(for: positionIdentity),
+                    cascadeIndex: sessions.count
+                ))
                 Log.info("新建窗口内区域 PiP：\(source.displayTitle) \(Int(local.width))×\(Int(local.height))")
                 return
             }
@@ -132,8 +148,12 @@ final class SessionStore {
         // 否则退回显示器流 + 显示器局部裁剪
         let local = Geo.sckRect(fromScreenRect: result.screenRect, on: result.screen)
         let source = CaptureSource.region(displayID: result.displayID, rect: result.screenRect)
+        let positionIdentity = PositionMemoryIdentity.displayRegion(
+            displayID: result.displayID, rect: result.screenRect
+        )
         let request = SessionRequest(
             source: source,
+            positionIdentity: positionIdentity,
             baseSourceRect: local,
             sourcePixelSize: CGSize(width: local.width * scale, height: local.height * scale),
             sourcePointSize: local.size,
@@ -141,7 +161,11 @@ final class SessionStore {
             autoHide: Preferences.shared.autoHideDefault,
             idleDetection: Preferences.shared.idleDetectionDefault
         )
-        add(PiPSession(request: request, cascadeIndex: sessions.count))
+        add(PiPSession(
+            request: request,
+            initialOrigin: initialOrigin(for: positionIdentity),
+            cascadeIndex: sessions.count
+        ))
         Log.info("新建屏幕区域 PiP：\(Int(local.width))×\(Int(local.height)) @ display \(result.displayID)")
     }
 
@@ -175,6 +199,27 @@ final class SessionStore {
     }
 
     // MARK: - 内部
+
+    /// 精确的捕获目标位置优先。没有记录且同一回退命名空间已有 PiP 时，不复用旧版位置，
+    /// 让 `PiPWindowController` 的 cascade 布局生效；首个目标仍可沿用旧版本记住的位置。
+    private func initialOrigin(for identity: PositionMemoryIdentity) -> CGPoint? {
+        let prefs = Preferences.shared
+        let exact = prefs.origin(for: identity)
+        let hasActiveSibling = sessions.contains {
+            $0.positionFallbackPreferenceKey == identity.fallbackPreferenceKey
+        }
+        return Self.selectInitialOrigin(
+            exactOrigin: exact,
+            fallbackOrigin: prefs.fallbackOrigin(for: identity),
+            hasActiveSibling: hasActiveSibling
+        )
+    }
+
+    static func selectInitialOrigin(exactOrigin: CGPoint?, fallbackOrigin: CGPoint?,
+                                    hasActiveSibling: Bool) -> CGPoint? {
+        if let exactOrigin { return exactOrigin }
+        return hasActiveSibling ? nil : fallbackOrigin
+    }
 
     private func add(_ session: PiPSession) {
         session.onClose = { [weak self] closed in

--- a/Tests/MyWindowPipTests/WindowPositionMemoryTests.swift
+++ b/Tests/MyWindowPipTests/WindowPositionMemoryTests.swift
@@ -1,0 +1,170 @@
+import AppKit
+import XCTest
+@testable import my_window_pip
+
+final class WindowPositionMemoryTests: XCTestCase {
+
+    private final class TestClock {
+        private(set) var value: TimeInterval = 0
+        func next() -> TimeInterval {
+            value += 1
+            return value
+        }
+    }
+
+    private func makePreferences(clock: TestClock = TestClock()) -> (Preferences, UserDefaults) {
+        let suiteName = "WindowPositionMemoryTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock { defaults.removePersistentDomain(forName: suiteName) }
+        return (Preferences(defaults: defaults, now: { clock.next() }), defaults)
+    }
+
+    func testWindowPositionKeyUsesWindowIDAndIgnoresChangingTitle() {
+        let first = CaptureSource.window(
+            id: 42, bundleID: "com.todesktop.230313mzl4w4u92", appName: "Cursor", title: "a.swift"
+        )
+        let renamed = CaptureSource.window(
+            id: 42, bundleID: "com.todesktop.230313mzl4w4u92", appName: "Cursor", title: "b.swift"
+        )
+        let sibling = CaptureSource.window(
+            id: 43, bundleID: "com.todesktop.230313mzl4w4u92", appName: "Cursor", title: "a.swift"
+        )
+        let firstIdentity = PositionMemoryIdentity.window(
+            appPreferenceKey: first.preferenceKey, windowID: first.windowID!
+        )
+        let renamedIdentity = PositionMemoryIdentity.window(
+            appPreferenceKey: renamed.preferenceKey, windowID: renamed.windowID!
+        )
+        let siblingIdentity = PositionMemoryIdentity.window(
+            appPreferenceKey: sibling.preferenceKey, windowID: sibling.windowID!
+        )
+
+        XCTAssertEqual(firstIdentity.preferenceKey, renamedIdentity.preferenceKey)
+        XCTAssertNotEqual(firstIdentity.preferenceKey, siblingIdentity.preferenceKey)
+        XCTAssertEqual(firstIdentity.fallbackPreferenceKey, siblingIdentity.fallbackPreferenceKey)
+    }
+
+    func testCaptureRegionsHaveIndependentPositionKeys() {
+        let appKey = "com.microsoft.VSCode"
+        let whole = PositionMemoryIdentity.window(appPreferenceKey: appKey, windowID: 42)
+        let regionA = PositionMemoryIdentity.windowRegion(
+            appPreferenceKey: appKey, windowID: 42, rect: CGRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        let regionB = PositionMemoryIdentity.windowRegion(
+            appPreferenceKey: appKey, windowID: 42, rect: CGRect(x: 10, y: 0, width: 400, height: 300)
+        )
+        let displayA = PositionMemoryIdentity.displayRegion(
+            displayID: 1, rect: CGRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        let displayB = PositionMemoryIdentity.displayRegion(
+            displayID: 2, rect: CGRect(x: 0, y: 0, width: 400, height: 300)
+        )
+
+        XCTAssertNotEqual(whole.preferenceKey, regionA.preferenceKey)
+        XCTAssertNotEqual(regionA.preferenceKey, regionB.preferenceKey)
+        XCTAssertNotEqual(displayA.preferenceKey, displayB.preferenceKey)
+    }
+
+    func testWindowRegionRetargetKeepsGeometryAndChangesWindowID() {
+        let original = PositionMemoryIdentity.windowRegion(
+            appPreferenceKey: "com.microsoft.VSCode",
+            windowID: 42,
+            rect: CGRect(x: 10, y: 20, width: 400, height: 300)
+        )
+        let rematched = original.retargetingWindow(to: .window(
+            id: 99,
+            bundleID: "com.microsoft.VSCode",
+            appName: "Visual Studio Code",
+            title: "changed title"
+        ))
+
+        XCTAssertNotEqual(original.preferenceKey, rematched.preferenceKey)
+        XCTAssertEqual(original.fallbackPreferenceKey, rematched.fallbackPreferenceKey)
+        XCTAssertTrue(rematched.preferenceKey.contains(":99:"))
+    }
+
+    func testExactOriginWinsEvenWhenSiblingIsActive() {
+        let exact = CGPoint(x: 100, y: 200)
+
+        XCTAssertEqual(
+            SessionStore.selectInitialOrigin(
+                exactOrigin: exact,
+                fallbackOrigin: CGPoint(x: 300, y: 400),
+                hasActiveSibling: true
+            ),
+            exact
+        )
+    }
+
+    func testNewSiblingUsesCascadeInsteadOfSharedFallbackOrigin() {
+        XCTAssertNil(
+            SessionStore.selectInitialOrigin(
+                exactOrigin: nil,
+                fallbackOrigin: CGPoint(x: 300, y: 400),
+                hasActiveSibling: true
+            )
+        )
+    }
+
+    func testFirstCaptureCanUseLegacyFallbackOrigin() {
+        let fallback = CGPoint(x: 300, y: 400)
+
+        XCTAssertEqual(
+            SessionStore.selectInitialOrigin(
+                exactOrigin: nil, fallbackOrigin: fallback, hasActiveSibling: false
+            ),
+            fallback
+        )
+    }
+
+    func testPreferencesPersistExactAndFallbackOrigins() {
+        let (prefs, defaults) = makePreferences()
+        let first = PositionMemoryIdentity.window(appPreferenceKey: "com.example.editor", windowID: 1)
+        let second = PositionMemoryIdentity.window(appPreferenceKey: "com.example.editor", windowID: 2)
+        let firstOrigin = CGPoint(x: 100, y: 200)
+        let secondOrigin = CGPoint(x: 300, y: 400)
+
+        prefs.setOrigin(firstOrigin, for: first)
+        prefs.setOrigin(secondOrigin, for: second)
+
+        let reloaded = Preferences(defaults: defaults)
+        XCTAssertEqual(reloaded.origin(for: first), firstOrigin)
+        XCTAssertEqual(reloaded.origin(for: second), secondOrigin)
+        XCTAssertEqual(reloaded.fallbackOrigin(for: first), secondOrigin)
+    }
+
+    func testPreferencesReadLegacyAppOriginAsFallback() {
+        let (prefs, defaults) = makePreferences()
+        defaults.set(["com.example.editor": [12.0, 34.0]], forKey: "originByApp")
+        let identity = PositionMemoryIdentity.window(
+            appPreferenceKey: "com.example.editor", windowID: 42
+        )
+
+        XCTAssertNil(prefs.origin(for: identity))
+        XCTAssertEqual(prefs.fallbackOrigin(for: identity), CGPoint(x: 12, y: 34))
+    }
+
+    func testPositionOriginLRUKeepsRecentlyReadEntry() {
+        let clock = TestClock()
+        let (prefs, _) = makePreferences(clock: clock)
+        let identities = (1...128).map {
+            PositionMemoryIdentity.window(
+                appPreferenceKey: "com.example.editor", windowID: CGWindowID($0)
+            )
+        }
+        for (index, identity) in identities.enumerated() {
+            prefs.setOrigin(CGPoint(x: index, y: index), for: identity)
+        }
+
+        XCTAssertNotNil(prefs.origin(for: identities[0])) // 刷新第一条的最近使用时间
+        let newest = PositionMemoryIdentity.window(
+            appPreferenceKey: "com.example.editor", windowID: 129
+        )
+        prefs.setOrigin(CGPoint(x: 129, y: 129), for: newest)
+
+        XCTAssertNotNil(prefs.origin(for: identities[0]))
+        XCTAssertNil(prefs.origin(for: identities[1]))
+        XCTAssertNotNil(prefs.origin(for: newest))
+    }
+}


### PR DESCRIPTION
## Summary

- remember PiP origins per source window instead of sharing one origin across an application
- give whole-window, window-region, and display-region captures independent position identities without relying on mutable window titles
- preserve application-level origins as a backward-compatible fallback, cascade new sibling PiPs, and cap exact position history with LRU cleanup
- add deterministic persistence, migration, region identity, rematch, and eviction tests

## Root cause

Position, width, and frame-rate preferences previously shared the same application-level key. Once one window saved an origin, every other window from that application restored the same origin and bypassed the existing cascade layout.

## Behavior and compatibility

- Window titles are not part of the identity, so VSCode, Cursor, and similar apps can change files or tabs without losing the mapping.
- Width and frame-rate preferences remain application-level.
- Existing application-level origins are retained as a fallback. If a source window is recreated and no exact instance record exists, the first PiP uses that fallback while additional sibling PiPs use the cascade layout.
- Exact capture-target records are limited to the 128 most recently used entries.

## Validation

- `swift test` — 20 tests passed
- full x86_64 source typecheck with the macOS 14 target
- fork GitHub Actions `test` check passed
- `git diff --check`
