### PR TITLE
支持跨 Space 选择窗口并优化权限体验

### DIFF
--- a/Sources/my-window-pip/AppDelegate.swift
+++ b/Sources/my-window-pip/AppDelegate.swift
@@ -26,15 +26,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.warn("增强模式无法启用（辅助功能权限缺失），已回退到零权限模式")
         }
 
-        // 首次运行且未授权时：先向系统申请（这一步会弹系统授权框，并把本应用登记进
-        // 「屏幕录制与系统录音」列表，用户直接开开关即可，不用手动点加号），
-        // 仍未授权才显示我们的引导框。菜单栏的告警项会在下次打开菜单时自动消失。
-        if !Permissions.hasScreenRecording {
+        // 首次运行且未授权时只向系统申请（会弹系统授权框，并把本应用登记进
+        // 「屏幕录制与系统录音」列表）；App 自己的引导留到用户之后仍主动触发捕获时，
+        // 避免两层弹窗叠在一起。菜单栏的告警项会在下次打开菜单时自动消失。
+        let hadScreenRecordingPermission = Permissions.hasScreenRecording
+        if !hadScreenRecordingPermission {
             Permissions.ensureScreenRecording()
+        } else {
+            // 全 Space 的首次枚举比原来的 onscreen 查询更重；启动后立即在后台预热缓存，
+            // 避免用户第一次展开「选择窗口」时才看到加载占位。refresh 本身异步，不阻塞启动。
+            ShareableContentStore.shared.refresh { result in
+                switch result {
+                case let .success(windows):
+                    Log.debug("窗口列表预热完成：\(windows.count) 个候选窗口")
+                case let .failure(error):
+                    Log.warn("窗口列表预热失败：\(error.localizedDescription)")
+                }
+            }
         }
 
-        // 权限流程走完之后再弹首启引导，避免和系统授权框叠弹
-        if !Preferences.shared.hasSeenOnboarding {
+        // 未授权的首次启动只显示系统授权框；上手引导留到授权并重启后，避免两层 UI 叠弹。
+        if hadScreenRecordingPermission, !Preferences.shared.hasSeenOnboarding {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
                 self?.showOnboarding(markAsSeen: true)
             }
@@ -388,11 +400,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 SessionStore.shared.pipFrontmostWindow()
                 return
             }
-            // 多路并发：取面积最大的前 N 个普通窗口
+            // 多路并发：全量枚举包含其他 Space / 最小化窗口，自检只取当前在屏的普通窗口
             ShareableContentStore.shared.refresh { result in
                 guard case let .success(windows) = result else { return }
                 let targets = windows
-                    .filter { $0.windowLayer == 0 }
+                    .filter { $0.isOnScreen && $0.windowLayer == 0 }
                     .sorted { $0.frame.width * $0.frame.height > $1.frame.width * $1.frame.height }
                     .prefix(sessionCount)
                 for window in targets { SessionStore.shared.pip(window: window) }

--- a/Sources/my-window-pip/CaptureEngine.swift
+++ b/Sources/my-window-pip/CaptureEngine.swift
@@ -316,7 +316,7 @@ final class CaptureEngine: NSObject, SCStreamOutput, SCStreamDelegate {
     // MARK: - 卡流检测
 
     /// 内部定时器：超过 `max(2s, 3/fps)` 没收到有效帧就报一次 `captureDidStall()`（主线程）。
-    /// 源窗口最小化、所在 Space 不可见时 SCK 会停止产出 `.complete` 帧，靠这个感知。
+    /// 源窗口最小化、被系统挂起或捕获链路暂时不可用时，SCK 可能停止产出 `.complete` 帧。
     private func startStallWatchdog() {
         stallLock.lock()
         lastFrameUptime = ProcessInfo.processInfo.systemUptime

--- a/Sources/my-window-pip/Permissions.swift
+++ b/Sources/my-window-pip/Permissions.swift
@@ -7,16 +7,25 @@ enum Permissions {
 
     // MARK: - 屏幕录制
 
-    /// 本进程是否已经触发过一次系统授权请求。只在主线程访问；用于避免系统授权框刚出现，
-    /// `ensureScreenRecording()` 就立刻再叠一层 App 自己的说明框。
-    private static var didRequestScreenRecordingThisLaunch = false
+    /// 原子记录本进程是否已经触发过系统授权请求，避免并发入口重复请求或叠加 App 引导。
+    private final class ScreenRecordingRequestState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didRequest = false
+
+        /// 首个调用方把状态置为已请求并返回 true；后续调用返回 false。
+        func beginRequestIfNeeded() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didRequest else { return false }
+            didRequest = true
+            return true
+        }
+    }
+
+    private static let screenRecordingRequestState = ScreenRecordingRequestState()
 
     /// 不弹窗的预检。
     static var hasScreenRecording: Bool { CGPreflightScreenCaptureAccess() }
-
-    /// 首次调用会触发系统授权弹窗；已被拒绝时直接返回 false。
-    @discardableResult
-    static func requestScreenRecording() -> Bool { CGRequestScreenCaptureAccess() }
 
     /// 让系统把本应用登记进「屏幕录制与系统录音」列表。
     ///
@@ -26,8 +35,7 @@ enum Permissions {
     /// 1. `CGRequestScreenCaptureAccess()` 触发系统授权弹窗并写入 TCC 条目
     /// 2. 再发一次 ScreenCaptureKit 查询，确保 SCK 侧也完成登记（失败被系统吞掉是正常的）
     @discardableResult
-    static func primeRegistration() -> Bool {
-        didRequestScreenRecordingThisLaunch = true
+    private static func primeRegistration() -> Bool {
         let granted = CGRequestScreenCaptureAccess()
         Task.detached(priority: .utility) {
             _ = try? await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
@@ -43,7 +51,7 @@ enum Permissions {
     @discardableResult
     static func ensureScreenRecording() -> Bool {
         if hasScreenRecording { return true }
-        if !didRequestScreenRecordingThisLaunch {
+        if screenRecordingRequestState.beginRequestIfNeeded() {
             _ = primeRegistration()
             // 系统授权可能要求重启应用才生效；这里只复检，不在同一轮再弹 App 引导。
             return hasScreenRecording

--- a/Sources/my-window-pip/Permissions.swift
+++ b/Sources/my-window-pip/Permissions.swift
@@ -7,6 +7,10 @@ enum Permissions {
 
     // MARK: - 屏幕录制
 
+    /// 本进程是否已经触发过一次系统授权请求。只在主线程访问；用于避免系统授权框刚出现，
+    /// `ensureScreenRecording()` 就立刻再叠一层 App 自己的说明框。
+    private static var didRequestScreenRecordingThisLaunch = false
+
     /// 不弹窗的预检。
     static var hasScreenRecording: Bool { CGPreflightScreenCaptureAccess() }
 
@@ -23,6 +27,7 @@ enum Permissions {
     /// 2. 再发一次 ScreenCaptureKit 查询，确保 SCK 侧也完成登记（失败被系统吞掉是正常的）
     @discardableResult
     static func primeRegistration() -> Bool {
+        didRequestScreenRecordingThisLaunch = true
         let granted = CGRequestScreenCaptureAccess()
         Task.detached(priority: .utility) {
             _ = try? await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
@@ -30,13 +35,19 @@ enum Permissions {
         return granted
     }
 
-    /// 确保拥有屏幕录制权限：先向系统申请（顺带完成列表登记），仍未授权才显示引导。
+    /// 确保拥有屏幕录制权限。
+    ///
+    /// 首次调用只发起 macOS 系统授权：系统弹窗是实际授予 TCC 权限的唯一入口，不与 App
+    /// 自己的说明框叠加。若本次启动已经请求过、用户之后仍主动触发捕获或点击权限菜单，
+    /// 才显示 App 引导，提供系统设置、重置记录与重启入口。
     @discardableResult
     static func ensureScreenRecording() -> Bool {
         if hasScreenRecording { return true }
-        if primeRegistration() { return true }
-        // 系统弹窗是异步的，用户可能刚点了「允许」，复检一次避免多弹一个框
-        if hasScreenRecording { return true }
+        if !didRequestScreenRecordingThisLaunch {
+            _ = primeRegistration()
+            // 系统授权可能要求重启应用才生效；这里只复检，不在同一轮再弹 App 引导。
+            return hasScreenRecording
+        }
         showScreenRecordingGuide()
         return false
     }

--- a/Sources/my-window-pip/PiPSession.swift
+++ b/Sources/my-window-pip/PiPSession.swift
@@ -455,7 +455,7 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     func captureDidStall() {
         guard !isClosed, !state.isPaused, !state.isHidden, !isAutoHidden else { return }
-        // 没有新帧通常意味着源窗口被最小化或所在 Space 不可见
+        // 没有新帧通常意味着源窗口最小化、被系统挂起或捕获链路暂时不可用。
         update(runtimeState: .waitingForSource)
         startProbeTimer()
     }

--- a/Sources/my-window-pip/PlaceholderView.swift
+++ b/Sources/my-window-pip/PlaceholderView.swift
@@ -155,9 +155,9 @@ final class PlaceholderView: NSView {
             return Content(
                 symbols: ["arrow.down.right.and.arrow.up.left.circle",
                           "arrow.down.right.and.arrow.up.left"],
-                title: L.t("源窗口暂不可见", "Source window unavailable"),
-                subtitle: L.t("切回窗口所在 Space 或取消最小化后会自动继续",
-                              "Switch to its Space or restore it to resume automatically")
+                title: L.t("源窗口暂不可用", "Source window temporarily unavailable"),
+                subtitle: L.t("切回源窗口或取消最小化后会自动继续",
+                              "Bring the source window forward or restore it to resume automatically")
             )
 
         case let .reconnecting(attempt):

--- a/Sources/my-window-pip/PlaceholderView.swift
+++ b/Sources/my-window-pip/PlaceholderView.swift
@@ -155,9 +155,9 @@ final class PlaceholderView: NSView {
             return Content(
                 symbols: ["arrow.down.right.and.arrow.up.left.circle",
                           "arrow.down.right.and.arrow.up.left"],
-                title: L.t("源窗口已最小化", "Source window minimized"),
-                subtitle: L.t("恢复「\(source.displayTitle)」后会自动继续",
-                              "Restore \(source.displayTitle) to resume automatically")
+                title: L.t("源窗口暂不可见", "Source window unavailable"),
+                subtitle: L.t("切回窗口所在 Space 或取消最小化后会自动继续",
+                              "Switch to its Space or restore it to resume automatically")
             )
 
         case let .reconnecting(attempt):

--- a/Sources/my-window-pip/SelfTest.swift
+++ b/Sources/my-window-pip/SelfTest.swift
@@ -45,9 +45,11 @@ enum SelfTest {
             return 3
         }
         print("可捕获窗口：\(windows.count) 个")
+        // 全量枚举包含其他 Space 与最小化窗口；自检必须只挑当前能稳定产出帧的 onscreen 窗口。
+        let onScreen = windows.filter { $0.isOnScreen }
         // 优先挑普通层（windowLayer == 0）的最大窗口，避免选到 Dock 这类系统层窗口
-        let normalLayer = windows.filter { $0.windowLayer == 0 }
-        let pool = normalLayer.isEmpty ? windows : normalLayer
+        let normalLayer = onScreen.filter { $0.windowLayer == 0 }
+        let pool = normalLayer.isEmpty ? onScreen : normalLayer
         guard let target = pool.max(by: {
             $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height
         }) else {

--- a/Sources/my-window-pip/SessionStore.swift
+++ b/Sources/my-window-pip/SessionStore.swift
@@ -85,7 +85,10 @@ final class SessionStore {
             idleDetection: Preferences.shared.idleDetectionDefault
         )
         add(PiPSession(request: request, cascadeIndex: sessions.count))
-        Log.info("新建窗口 PiP：\(source.displayTitle) @ \(request.fps.label)")
+        Log.info("""
+            新建窗口 PiP：\(source.displayTitle) @ \(request.fps.label) \
+            [windowID=\(window.windowID), isOnScreen=\(window.isOnScreen), isActive=\(window.isActive)]
+            """)
     }
 
     /// 区域捕获（热键 / 菜单入口）

--- a/Sources/my-window-pip/ShareableContentStore.swift
+++ b/Sources/my-window-pip/ShareableContentStore.swift
@@ -53,8 +53,8 @@ final class ShareableContentStore: @unchecked Sendable {
     private var displaysCache: [SCDisplay] = []
     /// 窗口在其所属 App 内的序号（1 起），用于无标题窗口的兜底命名
     private var ordinalCache: [CGWindowID: Int] = [:]
-    /// 上次成功查询的时间（`systemUptime`，单调）；初值取负数保证首次即为过期
-    private var lastSuccessUptime: TimeInterval = -.greatestFiniteMagnitude
+    /// 上次成功查询的时间（`systemUptime`，单调）；nil 表示尚无可供立即展示的快照
+    private var lastSuccessUptime: TimeInterval?
 
     /// 以下两个字段只在主线程读写
     private var isFetching = false
@@ -187,9 +187,27 @@ final class ShareableContentStore: @unchecked Sendable {
     }
 
     /// 按 App 分组（每组按标题排序），供菜单栏渲染。
-    func grouped(completion: @escaping ([WindowGroup]) -> Void) {
-        withFreshCache { [weak self] in
-            completion(self?.groupsFromCache() ?? [])
+    ///
+    /// 已有快照时先同步返回缓存，让菜单立即可用；若缓存已过期，再后台刷新并以第二次回调
+    /// 更新打开中的菜单。首次查询没有可回退的快照，仍会等异步枚举完成后回调一次。
+    func grouped(completion: @escaping (Result<[WindowGroup], Error>) -> Void) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        if hasSuccessfulSnapshot {
+            completion(.success(groupsFromCache()))
+            guard isCacheExpired else { return }
+            refresh { [weak self] result in
+                guard let self, case .success = result else { return }
+                completion(.success(self.groupsFromCache()))
+            }
+            return
+        }
+        refresh { [weak self] result in
+            switch result {
+            case .success:
+                completion(.success(self?.groupsFromCache() ?? []))
+            case let .failure(error):
+                completion(.failure(error))
+            }
         }
     }
 
@@ -209,7 +227,8 @@ final class ShareableContentStore: @unchecked Sendable {
                  completion: @escaping (SCWindow?) -> Void) {
         withFreshCache { [weak self] in
             guard let self else { completion(nil); return }
-            let candidates = self.cachedWindows.filter { window in
+            // 已经由 withFreshCache 负责刷新；直接取快照，避免刷新失败后 getter 立刻再发一次查询。
+            let candidates = self.withLock { self.candidatesCache }.filter { window in
                 guard let app = window.owningApplication else { return false }
                 if let bundleID, !bundleID.isEmpty { return app.bundleIdentifier == bundleID }
                 return app.applicationName.caseInsensitiveCompare(appName) == .orderedSame
@@ -221,7 +240,8 @@ final class ShareableContentStore: @unchecked Sendable {
     /// 按 displayID 找显示器（区域捕获重建流时用）。
     func display(id: CGDirectDisplayID, completion: @escaping (SCDisplay?) -> Void) {
         withFreshCache { [weak self] in
-            completion(self?.cachedDisplays.first { $0.displayID == id })
+            guard let self else { completion(nil); return }
+            completion(self.withLock { self.displaysCache.first { $0.displayID == id } })
         }
     }
 
@@ -264,7 +284,9 @@ final class ShareableContentStore: @unchecked Sendable {
 
     private func frontmostWindowFromCache() -> SCWindow? {
         let windows = withLock { candidatesCache }
-        let byID = Dictionary(uniqueKeysWithValues: windows.map { ($0.windowID, $0) })
+        // WindowServer 的 ID 按约定唯一；覆盖式构造仍可避免异常重复数据导致进程崩溃。
+        var byID: [CGWindowID: SCWindow] = [:]
+        for window in windows { byID[window.windowID] = window }
 
         // `SCShareableContent(... onScreenWindowsOnly: false)` 的结果还包含其他 Space 与最小化
         // 窗口，不能再依赖它的数组顺序。CGWindowList 给出当前 onscreen 窗口的前后顺序，
@@ -465,8 +487,11 @@ final class ShareableContentStore: @unchecked Sendable {
     // MARK: - 工具
 
     private var isExpiredLocked: Bool {
-        ProcessInfo.processInfo.systemUptime - lastSuccessUptime > Self.ttl
+        guard let lastSuccessUptime else { return true }
+        return ProcessInfo.processInfo.systemUptime - lastSuccessUptime > Self.ttl
     }
+
+    private var hasSuccessfulSnapshot: Bool { withLock { lastSuccessUptime != nil } }
 
     private func withLock<T>(_ body: () -> T) -> T {
         lock.lock()

--- a/Sources/my-window-pip/ShareableContentStore.swift
+++ b/Sources/my-window-pip/ShareableContentStore.swift
@@ -19,8 +19,9 @@ struct WindowGroup {
 /// 设计要点：
 /// - 单次查询要数十毫秒，菜单栏点开时必须立即有数据，因此做 1 秒 TTL 缓存；
 ///   过期时先返回旧值再触发后台刷新（getter 不阻塞）。
-/// - 缓存分三份：`candidates`（可作为 PiP 源，已过滤）、`all`（不含自身 App 的全部窗口，
-///   供按 ID 精确查找）、`own`（自身 App 的窗口，区域捕获时要排除，防止镜中镜）。
+/// - 枚举范围覆盖全部 Space；缓存分三份：`candidates`（可作为 PiP 源，已过滤）、`all`
+///   （不含自身 App 的全部窗口，供按 ID 精确查找）、`own`（自身 App 的窗口，区域捕获时
+///   要排除，防止镜中镜）。前台窗口入口再单独按 onscreen + WindowServer 层级收窄。
 /// - 对外语义是「主线程访问」；但 `cachedWindow(id:)` 属于高频路径，可能在捕获队列上被调用，
 ///   因此所有缓存读写都用一把锁保护，跨线程读取安全（读到的是某一时刻的快照）。
 ///
@@ -105,8 +106,10 @@ final class ShareableContentStore: @unchecked Sendable {
         // SCShareableContent 的查询是 async throws，包在 Task 里执行，结果切回主线程处理。
         Task {
             do {
+                // 菜单、按 ID 存活检查和断线重连都必须能看到其他 Space / 最小化窗口。
+                // 是否位于当前前台只属于 `frontmostWindow` 的选择条件，不能在枚举源头过滤。
                 let content = try await SCShareableContent.excludingDesktopWindows(
-                    true, onScreenWindowsOnly: true
+                    true, onScreenWindowsOnly: false
                 )
                 let snapshot = ContentSnapshot(content)
                 DispatchQueue.main.async { self.finishRefresh(.success(snapshot)) }
@@ -176,7 +179,7 @@ final class ShareableContentStore: @unchecked Sendable {
 
     // MARK: - 查询接口
 
-    /// 前台 App 的主窗口：pid 匹配 + `windowLayer == 0` + 在屏 + 尺寸 > 80 + 面积最大。
+    /// 当前真正位于前台的主窗口：前台 App pid + WindowServer 前后顺序 + onscreen 普通层窗口。
     func frontmostWindow(completion: @escaping (SCWindow?) -> Void) {
         withFreshCache { [weak self] in
             completion(self?.frontmostWindowFromCache())
@@ -261,18 +264,40 @@ final class ShareableContentStore: @unchecked Sendable {
 
     private func frontmostWindowFromCache() -> SCWindow? {
         let windows = withLock { candidatesCache }
-        // 自身在前台（例如打开了设置窗口）时不按 pid 匹配，退化为「最前面的可捕获窗口」
-        var pid = NSWorkspace.shared.frontmostApplication?.processIdentifier
-        if pid == Self.ownProcessID { pid = nil }
+        let byID = Dictionary(uniqueKeysWithValues: windows.map { ($0.windowID, $0) })
 
-        if let pid {
-            let matched = windows.filter { window in
-                guard let app = window.owningApplication, app.processID == pid else { return false }
-                return Self.isMainLike(window)
+        // `SCShareableContent(... onScreenWindowsOnly: false)` 的结果还包含其他 Space 与最小化
+        // 窗口，不能再依赖它的数组顺序。CGWindowList 给出当前 onscreen 窗口的前后顺序，
+        // 用 windowID 映射回 SCWindow 后，热键路径就不会选中后台 Space 的窗口。
+        let orderedIDs = Self.orderedOnScreenWindowIDs()
+        let orderedOnScreen = (orderedIDs ?? []).compactMap { byID[$0] }
+            // 出现在 CG 的 onscreen 列表本身就是实时可见性的证明，不再读取可能有 1 秒缓存
+            // 延迟的 `SCWindow.isOnScreen`；这里只校验普通窗口的层级与尺寸。
+            .filter(Self.hasMainWindowGeometry)
+
+        let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        if let pid = frontmostPID, pid != Self.ownProcessID {
+            if let frontmost = orderedOnScreen.first(where: {
+                $0.owningApplication?.processID == pid
+            }) {
+                return frontmost
             }
-            if let best = matched.max(by: { Self.area($0) < Self.area($1) }) { return best }
+
+            // CGWindowList 读取失败时仍按 SCK 的 onscreen 状态尽力兜底；只在前台 App 内选择。
+            if orderedIDs == nil,
+               let fallback = windows.first(where: {
+                   $0.owningApplication?.processID == pid && Self.isMainLike($0)
+               }) {
+                return fallback
+            }
+            // 前台 App 没有可捕获的 onscreen 主窗口时返回 nil，不能误选另一个 App / Space。
+            return nil
         }
-        // 兜底：SCShareableContent 的窗口按前后顺序返回，取第一个像主窗口的
+
+        // 自身在前台（例如从状态栏菜单触发）时，退化为最前面的非自身可捕获窗口。
+        if let frontmost = orderedOnScreen.first { return frontmost }
+        guard orderedIDs == nil else { return nil }
+        // CGWindowList 读取失败时的最终兜底仍强制 onscreen，绝不选其他 Space / 最小化窗口。
         return windows.first(where: Self.isMainLike)
     }
 
@@ -323,21 +348,61 @@ final class ShareableContentStore: @unchecked Sendable {
         return false
     }
 
-    /// 是否可作为 PiP 源：尺寸够大，且不是「无标题的小浮层」。
+    /// 是否适合出现在窗口选择菜单。
+    ///
+    /// 全 Space 枚举会带回大量后台代理、隐藏菜单栏 App 的辅助窗和无标题离屏表面；它们虽然
+    /// 在 WindowServer 中“可共享”，却不是用户理解中的应用窗口。这里保留普通 App 的窗口，
+    /// 以及当前确实显示在屏幕上的有标题 accessory 窗口，再做尺寸与标题过滤。
     private static func isCandidate(_ window: SCWindow) -> Bool {
+        guard window.windowLayer == 0,
+              let owner = window.owningApplication,
+              owner.processID > 0 else { return false }
+
+        let title = trimmedTitle(of: window)
+        guard let runningApp = NSRunningApplication(processIdentifier: owner.processID),
+              !runningApp.isTerminated,
+              !runningApp.isHidden else { return false }
+        switch runningApp.activationPolicy {
+        case .regular:
+            break
+        case .accessory:
+            // 菜单栏 App 等 accessory 进程只保留眼下可见、明确有标题的用户界面。
+            guard window.isOnScreen, !title.isEmpty else { return false }
+        case .prohibited:
+            return false
+        @unknown default:
+            guard window.isOnScreen, !title.isEmpty else { return false }
+        }
+
         let frame = window.frame
         guard frame.width.isFinite, frame.height.isFinite else { return false }
         guard frame.width >= minWindowSide, frame.height >= minWindowSide else { return false }
-        if trimmedTitle(of: window).isEmpty, area(window) < minUntitledArea { return false }
+        // 非当前 Space 的正常文档窗口通常都有标题；无标题离屏窗口绝大多数是内部渲染表面。
+        if !window.isOnScreen, title.isEmpty { return false }
+        if title.isEmpty, area(window) < minUntitledArea { return false }
         return true
     }
 
     /// 像「App 主窗口」：普通层级 + 在屏 + 尺寸大于阈值。
     private static func isMainLike(_ window: SCWindow) -> Bool {
-        window.isOnScreen
-            && window.windowLayer == 0
+        window.isOnScreen && hasMainWindowGeometry(window)
+    }
+
+    /// 普通主窗口的稳定属性；是否在屏由调用方根据实时信息另行判断。
+    private static func hasMainWindowGeometry(_ window: SCWindow) -> Bool {
+        window.windowLayer == 0
             && window.frame.width > minWindowSide
             && window.frame.height > minWindowSide
+    }
+
+    /// WindowServer 当前 onscreen 窗口的前后顺序（最前面的在前）。
+    private static func orderedOnScreenWindowIDs() -> [CGWindowID]? {
+        guard let list = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] else { return nil }
+        return list.compactMap { info in
+            (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value
+        }
     }
 
     private static func area(_ window: SCWindow) -> CGFloat {

--- a/Sources/my-window-pip/StatusBarController.swift
+++ b/Sources/my-window-pip/StatusBarController.swift
@@ -235,10 +235,19 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
             for window in group.windows {
                 let title = ShareableContentStore.shared.displayTitle(for: window)
-                let item = NSMenuItem(title: "  \(title)", action: #selector(pipWindow(_:)),
+                // SCK 没有公开字段区分「其他 Space」与「已最小化」；测试版把两者都保留，
+                // 并明确标记，便于验证非当前 Space 的窗口能否持续产出实时帧。
+                let availability = window.isOnScreen ? "" : L.t("（未显示）", " (not visible)")
+                let item = NSMenuItem(title: "  \(title)\(availability)", action: #selector(pipWindow(_:)),
                                       keyEquivalent: "")
                 item.target = self
                 item.representedObject = NSNumber(value: window.windowID)
+                item.toolTip = window.isOnScreen
+                    ? "windowID=\(window.windowID) · isActive=\(window.isActive)"
+                    : L.t(
+                        "窗口位于其他 Space、屏幕外或已最小化 · windowID=\(window.windowID) · isActive=\(window.isActive)",
+                        "Window is in another Space, offscreen, or minimized · windowID=\(window.windowID) · isActive=\(window.isActive)"
+                    )
                 if store.session(windowID: window.windowID) != nil {
                     item.state = .on   // 已经有浮窗
                 }

--- a/Sources/my-window-pip/StatusBarController.swift
+++ b/Sources/my-window-pip/StatusBarController.swift
@@ -8,6 +8,8 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private let menu = NSMenu()
     private let windowsMenu = NSMenu()
     private var cachedGroups: [WindowGroup] = []
+    private enum WindowListState { case loading, loaded, failed }
+    private var windowListState: WindowListState = .loading
     private var pendingUpdate: ReleaseInfo?
 
     private let store = SessionStore.shared
@@ -87,9 +89,16 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
     /// 异步刷新窗口列表；NSMenu 允许在打开状态下增删项，因此可以直接原地更新。
     private func refreshWindowList() {
-        ShareableContentStore.shared.grouped { [weak self] groups in
+        ShareableContentStore.shared.grouped { [weak self] result in
             guard let self else { return }
-            self.cachedGroups = groups
+            switch result {
+            case let .success(groups):
+                self.cachedGroups = groups
+                self.windowListState = .loaded
+            case .failure:
+                // 没有成功快照时才会返回 failure；已有旧缓存则继续显示旧缓存。
+                self.windowListState = .failed
+            }
             self.populateWindowsMenu()
         }
     }
@@ -215,9 +224,27 @@ final class StatusBarController: NSObject, NSMenuDelegate {
     private func populateWindowsMenu() {
         windowsMenu.removeAllItems()
 
+        guard Permissions.hasScreenRecording else {
+            let item = NSMenuItem(
+                title: L.t("授权屏幕录制后可选择窗口", "Grant Screen Recording access to choose a window"),
+                action: nil, keyEquivalent: ""
+            )
+            item.isEnabled = false
+            windowsMenu.addItem(item)
+            return
+        }
+
         guard !cachedGroups.isEmpty else {
-            let item = NSMenuItem(title: L.t("正在读取窗口列表…", "Loading windows…"),
-                                  action: nil, keyEquivalent: "")
+            let title: String
+            switch windowListState {
+            case .loading:
+                title = L.t("正在读取窗口列表…", "Loading windows…")
+            case .loaded:
+                title = L.t("未找到可用窗口", "No available windows")
+            case .failed:
+                title = L.t("暂时无法读取窗口列表", "Could not load windows")
+            }
+            let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
             item.isEnabled = false
             windowsMenu.addItem(item)
             return
@@ -235,19 +262,19 @@ final class StatusBarController: NSObject, NSMenuDelegate {
 
             for window in group.windows {
                 let title = ShareableContentStore.shared.displayTitle(for: window)
-                // SCK 没有公开字段区分「其他 Space」与「已最小化」；测试版把两者都保留，
-                // 并明确标记，便于验证非当前 Space 的窗口能否持续产出实时帧。
+                // SCK 没有公开字段区分「其他 Space」与「已最小化」。其他 Space 的普通窗口
+                // 可以持续捕获，因此保留所有候选，并对当前不在屏幕上的项做中性标记。
                 let availability = window.isOnScreen ? "" : L.t("（未显示）", " (not visible)")
                 let item = NSMenuItem(title: "  \(title)\(availability)", action: #selector(pipWindow(_:)),
                                       keyEquivalent: "")
                 item.target = self
                 item.representedObject = NSNumber(value: window.windowID)
-                item.toolTip = window.isOnScreen
-                    ? "windowID=\(window.windowID) · isActive=\(window.isActive)"
-                    : L.t(
-                        "窗口位于其他 Space、屏幕外或已最小化 · windowID=\(window.windowID) · isActive=\(window.isActive)",
-                        "Window is in another Space, offscreen, or minimized · windowID=\(window.windowID) · isActive=\(window.isActive)"
+                if !window.isOnScreen {
+                    item.toolTip = L.t(
+                        "窗口可能位于其他 Space、屏幕外或已最小化",
+                        "Window may be in another Space, offscreen, or minimized"
                     )
+                }
                 if store.session(windowID: window.windowID) != nil {
                     item.state = .on   // 已经有浮窗
                 }


### PR DESCRIPTION
## Summary

- 将窗口枚举扩展到所有 Space，同时过滤后台代理、辅助窗口和无意义的小窗口
- 使用 WindowServer 的实时 onscreen 层级保持“前台窗口”热键语义，避免误选其他 Space
- 保留跨 Space 的窗口 ID 查找与断线重连能力
- 启动时预热窗口缓存，并采用先显示缓存、后台刷新的菜单更新策略
- 避免系统录屏授权框与 App 引导框首次叠加，完善加载、空列表和失败状态提示

## Validation

- `swift build`
- `git diff --check`
- 手动验证 iTerm2 全屏位于独立 Space 时，其他 Space 的窗口可以被选择并持续产生实时画面

## Notes

ScreenCaptureKit 的 `isOnScreen` 无法区分其他 Space、屏幕外和最小化窗口，因此这些候选统一标记为“未显示”。