### PR TITLE
Fix cross-Space PiP lifecycle and interaction regressions

### DIFF
--- a/Sources/my-window-pip/CaptureEngine.swift
+++ b/Sources/my-window-pip/CaptureEngine.swift
@@ -116,6 +116,9 @@ final class CaptureEngine: NSObject, SCStreamOutput, SCStreamDelegate {
         cfg.colorSpaceName = CGColorSpace.sRGB
         cfg.queueDepth = 3                                   // 低帧率下不需要大缓冲，省内存
         cfg.scalesToFit = true
+        // 始终保留源内容比例。SCK 可能把有效窗口内容放进更大的 IOSurface，
+        // 每帧的 contentRect × scaleFactor 才是有效像素区域；renderer 会据此裁掉 padding。
+        cfg.preservesAspectRatio = true
         cfg.showsCursor = showsCursor
         cfg.capturesAudio = false                            // v2 预留：音频跟随
         // 单窗口捕获默认会带上窗口阴影，浮窗里会显示成一圈半透明边，去掉更干净
@@ -319,7 +322,8 @@ final class CaptureEngine: NSObject, SCStreamOutput, SCStreamDelegate {
     // MARK: - 卡流检测
 
     /// 内部定时器：超过 `max(2s, 3/fps)` 没收到有效帧就报一次 `captureDidStall()`（主线程）。
-    /// 源窗口最小化、所在 Space 不可见时 SCK 会停止产出 `.complete` 帧，靠这个感知。
+    /// SCK 可能因最小化、Space 切换或捕获链路暂时不可用而停止产出 `.complete` 帧；
+    /// 这里只报告 transport stall，窗口生命周期由 `PiPSession` 另行判断。
     private func startStallWatchdog() {
         stallLock.lock()
         lastFrameUptime = ProcessInfo.processInfo.systemUptime

--- a/Sources/my-window-pip/FrameGate.swift
+++ b/Sources/my-window-pip/FrameGate.swift
@@ -12,6 +12,20 @@ import ScreenCaptureKit
 ///    抽样步长 16 行 × 16 像素，1080p 全屏帧也只读 ~8k 个像素，实测远低于 0.1ms。
 enum FrameGate {
 
+    struct ContentGeometry: Equatable {
+        /// IOSurface / CVPixelBuffer 的完整像素尺寸。
+        let bufferSize: CGSize
+        /// SCK 元数据给出的有效内容区域，单位为 surface 像素，原点按 SCK 的左上坐标系解释。
+        let visibleRectPixels: CGRect
+
+        var hasPadding: Bool {
+            visibleRectPixels.minX > 0.5
+                || visibleRectPixels.minY > 0.5
+                || abs(visibleRectPixels.maxX - bufferSize.width) > 0.5
+                || abs(visibleRectPixels.maxY - bufferSize.height) > 0.5
+        }
+    }
+
     /// 指纹抽样步长（行 / 列，单位：像素）
     static let sampleStride = 16
 
@@ -76,18 +90,94 @@ enum FrameGate {
     // MARK: - attachment 附加信息
 
     /// 本帧实际有效内容的像素尺寸（`contentRect` × `scaleFactor`）。
-    ///
-    /// 用途：`scalesToFit` 下输出缓冲可能带黑边，或源窗口尺寸变化后输出还没跟上，
-    /// 上层可据此判断「源尺寸变了」并重算输出分辨率 / 宽高比。解析不出返回 nil。
     static func contentRectPixelSize(_ sb: CMSampleBuffer) -> CGSize? {
-        guard let info = attachments(sb),
+        contentGeometry(sb)?.visibleRectPixels.size
+    }
+
+    /// SCK 的 IOSurface 可能比有效窗口内容更大（尤其窗口重连/全屏切换后），黑边并不是源内容。
+    /// `contentRect` 的 attachment 是 surface 坐标，但在 `scalesToFit` 路径里不同 macOS / 源窗口
+    /// 会同时带 `scaleFactor` 与 `contentScale`；固定只乘其中一个会在重连后留下几像素黑边。
+    /// 这里把几种合法换算映射到真实 pixel-buffer，选择面积最大的合法候选（也就是最贴近
+    /// surface 的那个），renderer 再据此逐帧裁掉动态 padding。
+    static func contentGeometry(_ sb: CMSampleBuffer) -> ContentGeometry? {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sb),
+              let info = attachments(sb),
               let dict = info[.contentRect] as? NSDictionary,
               let rect = CGRect(dictionaryRepresentation: dict as CFDictionary) else { return nil }
-        let scale = (info[.scaleFactor] as? CGFloat) ?? 1
-        let factor = scale > 0 ? scale : 1
-        let size = CGSize(width: rect.width * factor, height: rect.height * factor)
-        guard size.width > 0, size.height > 0 else { return nil }
-        return size
+
+        let scaleFactor = positiveCGFloat(info[.scaleFactor]) ?? 1
+        let contentScale = positiveCGFloat(info[.contentScale])
+        let bufferSize = CGSize(
+            width: CVPixelBufferGetWidth(pixelBuffer),
+            height: CVPixelBufferGetHeight(pixelBuffer)
+        )
+        guard let visible = resolvedVisibleRectPixels(
+            contentRect: rect,
+            scaleFactor: scaleFactor,
+            contentScale: contentScale,
+            bufferSize: bufferSize
+        ) else { return nil }
+        return ContentGeometry(bufferSize: bufferSize, visibleRectPixels: visible)
+    }
+
+    /// 把 SCK 的 contentRect 解析到实际 pixel-buffer 坐标。拆成纯函数供回归测试。
+    static func resolvedVisibleRectPixels(
+        contentRect: CGRect,
+        scaleFactor: CGFloat,
+        contentScale: CGFloat?,
+        bufferSize: CGSize
+    ) -> CGRect? {
+        guard bufferSize.width > 1, bufferSize.height > 1,
+              contentRect.minX.isFinite, contentRect.minY.isFinite,
+              contentRect.width.isFinite, contentRect.height.isFinite,
+              contentRect.width > 1, contentRect.height > 1 else { return nil }
+
+        var factors: [CGFloat] = [scaleFactor]
+        if let contentScale, contentScale.isFinite, contentScale > 0 {
+            factors.append(scaleFactor * contentScale)
+            factors.append(contentScale)
+        }
+        factors.append(1)
+
+        var unique: [CGFloat] = []
+        for factor in factors where factor.isFinite && factor > 0 {
+            if !unique.contains(where: { abs($0 - factor) < 0.0001 }) { unique.append(factor) }
+        }
+
+        let surfaceBounds = CGRect(origin: .zero, size: bufferSize)
+        let tolerance: CGFloat = 2
+        var candidates: [CGRect] = []
+        for factor in unique {
+            let candidate = CGRect(
+                x: contentRect.minX * factor,
+                y: contentRect.minY * factor,
+                width: contentRect.width * factor,
+                height: contentRect.height * factor
+            )
+            guard candidate.minX >= -tolerance, candidate.minY >= -tolerance,
+                  candidate.maxX <= bufferSize.width + tolerance,
+                  candidate.maxY <= bufferSize.height + tolerance else { continue }
+            let clipped = candidate.intersection(surfaceBounds)
+            guard !clipped.isNull, clipped.width > 1, clipped.height > 1 else { continue }
+            candidates.append(clipped)
+        }
+
+        return candidates.max {
+            ($0.width * $0.height) < ($1.width * $1.height)
+        }
+    }
+
+    private static func positiveCGFloat(_ value: Any?) -> CGFloat? {
+        let raw: Double?
+        if let number = value as? NSNumber {
+            raw = number.doubleValue
+        } else if let number = value as? CGFloat {
+            raw = Double(number)
+        } else {
+            raw = nil
+        }
+        guard let raw, raw.isFinite, raw > 0 else { return nil }
+        return CGFloat(raw)
     }
 
     /// 本帧的脏矩形数量。SCK 只在内容真的变化时才写入非空 `dirtyRects`，

--- a/Sources/my-window-pip/GeometryUtils.swift
+++ b/Sources/my-window-pip/GeometryUtils.swift
@@ -17,6 +17,51 @@ enum Geo {
         return (min(max(w, 2), 4096), min(max(h, 2), 4096))
     }
 
+    /// 窗口尺寸是否像「覆盖屏幕主体的主窗口」。
+    /// 用于全屏/最大化 App 的前台窗口选择：排除 1920×132 这类横向辅助 surface，
+    /// 但允许菜单栏/圆角/Stage Manager 带来的少量尺寸差异。
+    static func isScreenFillingWindow(size: CGSize, screenSizes: [CGSize]) -> Bool {
+        screenSizes.contains { screen in
+            guard screen.width > 1, screen.height > 1 else { return false }
+            let widthRatio = size.width / screen.width
+            let heightRatio = size.height / screen.height
+            return widthRatio >= 0.85 && widthRatio <= 1.05
+                && heightRatio >= 0.75 && heightRatio <= 1.05
+        }
+    }
+
+    /// 首次创建 PiP 时的默认宽度策略。
+    ///
+    /// 普通窗口沿用「源宽度的一半，320…640pt」；接近整屏的窗口（典型为全屏 App）
+    /// 用更紧凑的「源宽度四分之一，320…480pt」，避免 1920pt 全屏窗口直接生成 640pt 宽 PiP。
+    /// 已记忆宽度优先，但旧版本自动写入的 640pt 默认值在全屏场景下迁移到新默认。
+    static func initialPiPWidth(
+        sourceSize: CGSize,
+        rememberedWidth: CGFloat?,
+        screenSizes: [CGSize],
+        isWindowSource: Bool
+    ) -> CGFloat {
+        let legacyDefaultMax: CGFloat = 640
+        let fullscreenDefaultMax: CGFloat = 480
+        let isFullscreenLike = isWindowSource && screenSizes.contains { screen in
+            guard screen.width > 1, screen.height > 1 else { return false }
+            let widthRatio = sourceSize.width / screen.width
+            let heightRatio = sourceSize.height / screen.height
+            return widthRatio >= 0.97 && widthRatio <= 1.03
+                && heightRatio >= 0.97 && heightRatio <= 1.03
+        }
+
+        if isFullscreenLike {
+            if let rememberedWidth, abs(rememberedWidth - legacyDefaultMax) > 0.5 {
+                return rememberedWidth
+            }
+            return min(max(sourceSize.width / 4, 320), fullscreenDefaultMax)
+        }
+
+        if let rememberedWidth { return rememberedWidth }
+        return min(max(sourceSize.width / 2, 320), legacyDefaultMax)
+    }
+
     // MARK: - 缩放 / 平移
 
     static func clampZoom(_ zoom: CGFloat) -> CGFloat {
@@ -98,6 +143,35 @@ enum Geo {
         return uniformShrink ? nil : sampled
     }
 
+    /// 把带 padding 的 IOSurface 放进视图时，只让 `visibleRectPixels` 映射到 `bounds`；
+    /// padding 被放到父视图裁剪范围之外。`visibleRectPixels` 使用 SCK 的左上原点像素坐标。
+    ///
+    /// 这里分别按 X/Y 缩放，是为了吸收 SCK 在整数像素取整后产生的 1–2px 比例误差，
+    /// 避免 AVSampleBufferDisplayLayer 再次 letterbox 出细黑边。
+    static func displayLayerFrame(
+        bufferSize: CGSize,
+        visibleRectPixels: CGRect,
+        in bounds: CGRect
+    ) -> CGRect? {
+        guard bufferSize.width > 1, bufferSize.height > 1,
+              visibleRectPixels.width > 1, visibleRectPixels.height > 1,
+              bounds.width > 1, bounds.height > 1 else { return nil }
+
+        let surfaceBounds = CGRect(origin: .zero, size: bufferSize)
+        let visible = visibleRectPixels.intersection(surfaceBounds)
+        guard !visible.isNull, visible.width > 1, visible.height > 1 else { return nil }
+
+        let sx = bounds.width / visible.width
+        let sy = bounds.height / visible.height
+        let bottomPadding = bufferSize.height - visible.maxY
+        return CGRect(
+            x: bounds.minX - visible.minX * sx,
+            y: bounds.minY - bottomPadding * sy,
+            width: bufferSize.width * sx,
+            height: bufferSize.height * sy
+        )
+    }
+
     // MARK: - 视图 ↔ 源坐标
 
     /// `videoGravity = .resizeAspect` 下，内容在视图内实际占据的矩形（视图坐标，左下原点）。
@@ -112,6 +186,55 @@ enum Geo {
             y: bounds.minY + (bounds.height - size.height) / 2,
             width: size.width, height: size.height
         )
+    }
+
+    /// Cmd 框选矩形（视图左下原点）→ 当前可见画面内的归一化矩形（左上原点）。
+    /// 选区超出实际内容时先裁到内容范围；返回值可直接映射到当前 sourceRect。
+    static func visibleNormalizedRect(forSelection rect: CGRect, aspect: CGSize, bounds: CGRect) -> CGRect? {
+        let content = contentRect(aspect: aspect, in: bounds)
+        let sel = rect.intersection(content)
+        guard !sel.isNull, sel.width > 8, sel.height > 8,
+              content.width > 1, content.height > 1 else { return nil }
+        return CGRect(
+            x: (sel.minX - content.minX) / content.width,
+            y: 1 - (sel.maxY - content.minY) / content.height,
+            width: sel.width / content.width,
+            height: sel.height / content.height
+        )
+    }
+
+    /// 当前可见 sourceRect 内的归一化矩形（左上原点）→ 精确源坐标矩形。
+    static func sourceRect(fromNormalizedVisibleRect normalized: CGRect, within visible: CGRect) -> CGRect? {
+        let n = normalized.intersection(CGRect(x: 0, y: 0, width: 1, height: 1))
+        guard !n.isNull, n.width > 0, n.height > 0,
+              visible.width > 1, visible.height > 1 else { return nil }
+        let mapped = CGRect(
+            x: visible.minX + n.minX * visible.width,
+            y: visible.minY + n.minY * visible.height,
+            width: n.width * visible.width,
+            height: n.height * visible.height
+        ).intersection(visible)
+        guard !mapped.isNull, mapped.width > 1, mapped.height > 1 else { return nil }
+        return mapped
+    }
+
+    /// 把一个旧基准矩形中的子区域按归一化位置映射到新基准矩形。
+    /// 源窗口 resize / 兼容重启后用它保持用户已框选区域的相对位置与比例。
+    static func remap(_ rect: CGRect, from oldBase: CGRect, to newBase: CGRect) -> CGRect? {
+        guard oldBase.width > 1, oldBase.height > 1,
+              newBase.width > 1, newBase.height > 1 else { return nil }
+        let nx = (rect.minX - oldBase.minX) / oldBase.width
+        let ny = (rect.minY - oldBase.minY) / oldBase.height
+        let nw = rect.width / oldBase.width
+        let nh = rect.height / oldBase.height
+        let mapped = CGRect(
+            x: newBase.minX + nx * newBase.width,
+            y: newBase.minY + ny * newBase.height,
+            width: nw * newBase.width,
+            height: nh * newBase.height
+        ).intersection(newBase)
+        guard !mapped.isNull, mapped.width > 1, mapped.height > 1 else { return nil }
+        return mapped
     }
 
     /// 视图坐标点（左下原点）→ 当前可见画面的归一化坐标（左上原点，0…1）。
@@ -131,23 +254,6 @@ enum Geo {
         let half = 1 / (2 * z)
         let a = clampAnchor(anchor, zoom: z)
         return CGPoint(x: a.x - half + p.x / z, y: a.y - half + p.y / z)
-    }
-
-    /// 视图内的框选矩形 → 新的 (zoom, anchor)。
-    static func zoomAndAnchor(forSelection rect: CGRect, aspect: CGSize, bounds: CGRect,
-                              currentZoom: CGFloat, currentAnchor: CGPoint) -> (CGFloat, CGPoint)? {
-        let content = contentRect(aspect: aspect, in: bounds)
-        let sel = rect.intersection(content)
-        guard sel.width > 8, sel.height > 8 else { return nil }
-        // 选区在当前可见画面中的归一化尺寸
-        let visW = sel.width / content.width
-        let centerVisible = CGPoint(
-            x: (sel.midX - content.minX) / content.width,
-            y: 1 - (sel.midY - content.minY) / content.height
-        )
-        let sourceCenter = visibleNormToSourceNorm(centerVisible, zoom: currentZoom, anchor: currentAnchor)
-        let newZoom = clampZoom(currentZoom / visW)
-        return (newZoom, clampAnchor(sourceCenter, zoom: newZoom))
     }
 
     // MARK: - AppKit ↔ SCK 坐标

--- a/Sources/my-window-pip/HoverMonitor.swift
+++ b/Sources/my-window-pip/HoverMonitor.swift
@@ -3,13 +3,57 @@ import AppKit
 /// 鼠标悬停状态。
 /// - `isOverHotZone`：是否落在「热区」（浮窗顶栏）。自动隐藏开启后，画面区域穿透、
 ///   但顶栏仍要能悬停出现并操作，所以必须把这两个区域分开上报。
-/// - `optionHeld`：自动隐藏（点击穿透）时浮窗收不到任何事件，只能靠轮询出来的修饰键做「临时唤回」。
+/// - `optionHeld` / `commandHeld`：自动隐藏（点击穿透）时浮窗收不到任何事件，
+///   只能靠轮询出来的修饰键做「临时唤回」。⌥ 用于普通 peek，⌘ 用于恢复 Cmd 框选缩放。
 struct HoverState: Equatable {
     var isHovering: Bool
     var isOverHotZone: Bool
+    var isOverResizeZone: Bool
     var optionHeld: Bool
+    var commandHeld: Bool
 
-    static let none = HoverState(isHovering: false, isOverHotZone: false, optionHeld: false)
+    static let none = HoverState(
+        isHovering: false,
+        isOverHotZone: false,
+        isOverResizeZone: false,
+        optionHeld: false,
+        commandHeld: false
+    )
+}
+
+enum AutoHideHoverIntent: Equatable {
+    case leave
+    case resize
+    case bar
+    case command
+    case option
+    case fade
+}
+
+/// 纯策略：把 HoverMonitor 的零权限轮询结果转换成自动隐藏动作，便于单元测试。
+func autoHideHoverIntent(for state: HoverState) -> AutoHideHoverIntent {
+    guard state.isHovering else { return .leave }
+    // 显式修饰键优先：Cmd 仍用于框选，Option 仍用于普通 peek。
+    if state.commandHeld { return .command }
+    if state.optionHeld { return .option }
+    // 边缘热区优先于顶栏：顶部最外圈要留给系统 resize，顶栏内部才用于按钮/拖动。
+    if state.isOverResizeZone { return .resize }
+    if state.isOverHotZone { return .bar }
+    return .fade
+}
+
+/// 点是否落在窗口边框周围的 resize 热区。热区同时覆盖窗口内外，保证从窗外靠近边缘时
+/// HoverMonitor 能先恢复鼠标命中，再把真正的 resize mouseDown 交给 AppKit。
+func isInResizeHotZone(point: CGPoint, frame: CGRect, thickness: CGFloat) -> Bool {
+    guard frame.width > 1, frame.height > 1, thickness > 0 else { return false }
+    let expanded = frame.insetBy(dx: -thickness, dy: -thickness)
+    guard expanded.contains(point) else { return false }
+
+    let distance = min(
+        abs(point.x - frame.minX), abs(point.x - frame.maxX),
+        abs(point.y - frame.minY), abs(point.y - frame.maxY)
+    )
+    return distance <= thickness
 }
 
 /// 鼠标悬停监控。
@@ -24,6 +68,7 @@ final class HoverMonitor {
     private struct Entry {
         let frameProvider: () -> CGRect?
         let hotZoneProvider: () -> CGRect?
+        let resizeZoneThicknessProvider: () -> CGFloat
         let onChange: (HoverState) -> Void
         var lastState: HoverState
     }
@@ -47,11 +92,20 @@ final class HoverMonitor {
     ///   - hotZoneProvider: 热区（顶栏）frame；返回 nil 表示没有热区
     func register(id: UUID, frameProvider: @escaping () -> CGRect?,
                   hotZoneProvider: @escaping () -> CGRect? = { nil },
+                  resizeZoneThicknessProvider: @escaping () -> CGFloat = { 0 },
                   onChange: @escaping (HoverState) -> Void) {
-        entries[id] = Entry(frameProvider: frameProvider, hotZoneProvider: hotZoneProvider,
-                            onChange: onChange, lastState: .none)
+        entries[id] = Entry(
+            frameProvider: frameProvider,
+            hotZoneProvider: hotZoneProvider,
+            resizeZoneThicknessProvider: resizeZoneThicknessProvider,
+            onChange: onChange,
+            lastState: .none
+        )
         startIfNeeded()
     }
+
+    /// 最近一次派发给指定浮窗的状态。live resize 结束后用它立即恢复正确的 auto-hide 决策。
+    func currentState(for id: UUID) -> HoverState { entries[id]?.lastState ?? .none }
 
     func unregister(id: UUID) {
         entries.removeValue(forKey: id)
@@ -83,13 +137,23 @@ final class HoverMonitor {
 
     @objc private func tick() {
         let mouse = NSEvent.mouseLocation
-        let optionHeld = NSEvent.modifierFlags.contains(.option)
+        let modifiers = NSEvent.modifierFlags
+        let optionHeld = modifiers.contains(.option)
+        let commandHeld = modifiers.contains(.command)
 
-        // 命中最上面的一个：按注册顺序无法判断 z 序，改为取包含鼠标且面积最小的窗口，
-        // 多个浮窗重叠时体验上更符合直觉。
+        // 命中最上面的一个：除了窗口内部，也把边缘外侧的 resize 热区算作命中。
+        // 按注册顺序无法判断 z 序，仍取面积最小的候选，维持现有重叠窗口体验。
         var hit: (id: UUID, area: CGFloat)?
+        var resizeHits: [UUID: Bool] = [:]
         for (id, entry) in entries {
-            guard let frame = entry.frameProvider(), frame.contains(mouse) else { continue }
+            guard let frame = entry.frameProvider() else { continue }
+            let resizeHit = isInResizeHotZone(
+                point: mouse,
+                frame: frame,
+                thickness: max(0, entry.resizeZoneThicknessProvider())
+            )
+            resizeHits[id] = resizeHit
+            guard frame.contains(mouse) || resizeHit else { continue }
             let area = frame.width * frame.height
             if hit == nil || area < hit!.area { hit = (id, area) }
         }
@@ -99,9 +163,13 @@ final class HoverMonitor {
         for (id, entry) in entries {
             let hovering = id == hoveredID
             let overHotZone = hovering && (entry.hotZoneProvider()?.contains(mouse) ?? false)
-            let state = HoverState(isHovering: hovering,
-                                   isOverHotZone: overHotZone,
-                                   optionHeld: hovering ? optionHeld : false)
+            let state = HoverState(
+                isHovering: hovering,
+                isOverHotZone: overHotZone,
+                isOverResizeZone: hovering && (resizeHits[id] ?? false),
+                optionHeld: hovering ? optionHeld : false,
+                commandHeld: hovering ? commandHeld : false
+            )
             guard state != entry.lastState else { continue }
             entries[id]?.lastState = state
             entry.onChange(state)

--- a/Sources/my-window-pip/Models.swift
+++ b/Sources/my-window-pip/Models.swift
@@ -106,8 +106,10 @@ struct PiPSessionState {
     var source: CaptureSource
     /// 放大倍率，1.0…20.0
     var zoom: CGFloat = 1.0
-    /// 放大中心（源画面归一化坐标，左上原点，0…1）
+    /// 放大中心（当前裁剪基准的归一化坐标，左上原点，0…1）
     var anchor: CGPoint = CGPoint(x: 0.5, y: 0.5)
+    /// Cmd 框选是否已经把捕获基准切成任意宽高比的子区域。
+    var hasSelectionCrop: Bool = false
     var fps: FPSStep = .fifteen
     var autoHide: Bool = false
     var idleDetection: Bool = true
@@ -152,6 +154,10 @@ struct IdleVerdict {
 enum SessionRuntimeState: Equatable {
     case streaming
     case paused
+    /// 源窗口处于其它 Space 等非当前可见状态。保留最后一帧，不显示关闭占位。
+    case sourceOffscreen
+    /// AX 明确确认用户点击黄色按钮最小化。
+    case minimized
     /// 源窗口已最小化 / 暂时不可见，等待恢复
     case waitingForSource
     /// 正在重连（第 n 次）
@@ -186,11 +192,17 @@ protocol PiPWindowDelegate: AnyObject {
     var currentSessionState: PiPSessionState { get }
 
     func pipRequestClose()
-    /// 请求缩放到指定倍率与锚点（锚点为源画面归一化坐标，左上原点）
+    /// 请求缩放到指定倍率与锚点（锚点为当前裁剪基准的归一化坐标，左上原点）
     func pipRequestZoom(_ zoom: CGFloat, anchor: CGPoint)
+    /// Cmd 框选：矩形是“当前可见画面”内的归一化区域（左上原点，0…1）。
+    /// 上层把它映射成精确 sourceRect，并把 PiP 宽高比改成该区域比例。
+    func pipRequestSelection(_ normalizedRect: CGRect)
     /// 归一化平移增量（正值表示画面向右/向下移动视野）
     func pipRequestPan(by delta: CGSize)
     func pipRequestZoomReset()
+    /// 系统 live resize 生命周期：自动隐藏模式用它锁住鼠标命中，避免拖动中途重新 click-through。
+    func pipWillStartLiveResize()
+    func pipDidEndLiveResize()
     /// 窗口尺寸变化（已 debounce）：新的逻辑尺寸与所在屏幕的 backingScaleFactor
     func pipDidResize(pointSize: CGSize, scale: CGFloat)
     func pipRequestFPS(_ fps: FPSStep)

--- a/Sources/my-window-pip/OverlayControlsView.swift
+++ b/Sources/my-window-pip/OverlayControlsView.swift
@@ -378,10 +378,16 @@ final class OverlayControlsView: NSView {
         setHintText(state.isPaused ? L.t("继续", "Resume") : L.t("暂停", "Pause"), for: pauseButton)
         pauseButton.setAccessibilityLabel(state.isPaused ? L.t("继续", "Resume") : L.t("暂停", "Pause"))
 
-        // 复位缩放：仅放大状态可用
+        // 复位：滚轮放大或 Cmd 框选任意比例后都可用。
         let zoomed = state.zoom > 1.001
-        resetZoomButton.isEnabled = zoomed
-        setTintRole(zoomed ? .inactive : .disabled, for: resetZoomButton)
+        let resettable = zoomed || state.hasSelectionCrop
+        resetZoomButton.isEnabled = resettable
+        setTintRole(resettable ? .inactive : .disabled, for: resetZoomButton)
+        let resetHint = state.hasSelectionCrop
+            ? L.t("恢复完整画面与原始比例", "Restore full frame and original aspect ratio")
+            : L.t("复位缩放", "Reset zoom")
+        setHintText(resetHint, for: resetZoomButton)
+        resetZoomButton.setAccessibilityLabel(resetHint)
 
         // 自动隐藏：开 → eye.slash（鼠标移入会淡出）
         autoHideButton.image = Self.symbolImage(
@@ -406,9 +412,12 @@ final class OverlayControlsView: NSView {
             offLabel: L.t("静止检测：关", "Idle detection: off")
         )
 
-        // 倍率标签
+        // 倍率 / 裁剪标签
         if zoomed {
             zoomLabel.stringValue = String(format: "%.1f×", Double(state.zoom))
+            zoomLabel.isHidden = false
+        } else if state.hasSelectionCrop {
+            zoomLabel.stringValue = L.t("选区", "Crop")
             zoomLabel.isHidden = false
         } else {
             zoomLabel.stringValue = ""

--- a/Sources/my-window-pip/PiPContentView.swift
+++ b/Sources/my-window-pip/PiPContentView.swift
@@ -15,8 +15,10 @@ final class PiPContentView: NSView {
 
     // MARK: - 对外回调
 
-    /// 请求缩放：(新倍率, 新锚点 —— 源画面归一化坐标，左上原点)
+    /// 请求缩放：(新倍率, 新锚点 —— 当前裁剪基准的归一化坐标，左上原点)
     var onRequestZoom: ((CGFloat, CGPoint) -> Void)?
+    /// Cmd 框选完成：当前可见画面内的归一化区域（左上原点）。
+    var onRequestSelection: ((CGRect) -> Void)?
     /// 请求平移：归一化视野位移（相对当前可见视野的比例，正值 = 视野向右/向下移动）
     var onRequestPan: ((CGSize) -> Void)?
     var onRequestZoomReset: (() -> Void)?
@@ -36,6 +38,8 @@ final class PiPContentView: NSView {
     // MARK: - 渲染
 
     private var displayLayer: AVSampleBufferDisplayLayer
+    /// 最近一帧 SCK 元数据描述的有效 IOSurface 区域。nil 时按完整 buffer 展示。
+    private var contentGeometry: FrameGate.ContentGeometry?
     /// Cmd + 拖拽的框选提示层
     private let selectionLayer = CAShapeLayer()
     /// display layer 进入 failed 状态时只打一次日志，避免刷屏
@@ -131,7 +135,7 @@ final class PiPContentView: NSView {
     override func layout() {
         super.layout()
         attachLayersIfNeeded()
-        displayLayer.frame = bounds
+        layoutDisplayLayer()
         selectionLayer.frame = bounds
     }
 
@@ -154,9 +158,43 @@ final class PiPContentView: NSView {
 
     private static func makeDisplayLayer() -> AVSampleBufferDisplayLayer {
         let layer = AVSampleBufferDisplayLayer()
-        layer.videoGravity = .resizeAspect
+        // 具体 aspect/padding 已由 SCStream 配置和逐帧 contentRect 处理；这里不要再次 letterbox。
+        layer.videoGravity = .resize
         layer.backgroundColor = NSColor.black.cgColor
         return layer
+    }
+
+    private func layoutDisplayLayer() {
+        let targetFrame: CGRect
+        if let geometry = contentGeometry,
+           let cropped = Geo.displayLayerFrame(
+               bufferSize: geometry.bufferSize,
+               visibleRectPixels: geometry.visibleRectPixels,
+               in: bounds
+           ) {
+            targetFrame = cropped
+        } else {
+            targetFrame = bounds
+        }
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        displayLayer.frame = targetFrame
+        CATransaction.commit()
+    }
+
+    private func updateContentGeometry(from sampleBuffer: CMSampleBuffer, at now: TimeInterval) {
+        guard let newGeometry = FrameGate.contentGeometry(sampleBuffer) else { return }
+        guard contentGeometry != newGeometry else { return }
+        contentGeometry = newGeometry
+        if newGeometry.hasPadding {
+            let v = newGeometry.visibleRectPixels
+            diagnostics.record(
+                "frame.content-padding buffer=\(Int(newGeometry.bufferSize.width))x\(Int(newGeometry.bufferSize.height)) "
+                    + "visible=\(Int(v.minX)),\(Int(v.minY)),\(Int(v.width))x\(Int(v.height))",
+                at: now
+            )
+        }
+        layoutDisplayLayer()
     }
 
     // MARK: - 状态注入
@@ -198,6 +236,7 @@ final class PiPContentView: NSView {
         let now = ProcessInfo.processInfo.systemUptime
         incomingFrameCount &+= 1
         lastIncomingUptime = now
+        updateContentGeometry(from: sampleBuffer, at: now)
         let renderer = displayLayer.sampleBufferRenderer
         recordRendererTransition(renderer, at: now)
 
@@ -294,6 +333,8 @@ final class PiPContentView: NSView {
         stallMonitor.reset()
         lastIncomingPTS = nil
         lastPixelSize = nil
+        contentGeometry = nil
+        layoutDisplayLayer()
         lastRendererStateSignature = nil
         cancelSelection()
         resetDragTracking()
@@ -385,9 +426,9 @@ final class PiPContentView: NSView {
         old.removeFromSuperlayer()
 
         let replacement = Self.makeDisplayLayer()
-        replacement.frame = bounds
         replacement.contentsScale = window?.backingScaleFactor ?? 2
         displayLayer = replacement
+        layoutDisplayLayer()
 
         if let root = layer {
             CATransaction.begin()
@@ -558,13 +599,19 @@ final class PiPContentView: NSView {
             let selection = Self.rect(from: start, to: convert(event.locationInWindow, from: nil))
             cancelSelection()
 
-            guard let result = Geo.zoomAndAnchor(forSelection: selection, aspect: aspect, bounds: bounds,
-                                                 currentZoom: zoom, currentAnchor: anchor) else { return }
-            // 本地先行更新，避免连续操作时用到过期的 zoom/anchor
-            zoom = result.0
-            anchor = result.1
+            guard let normalized = Geo.visibleNormalizedRect(
+                forSelection: selection,
+                aspect: aspect,
+                bounds: bounds
+            ) else { return }
+            // 新语义：框选区域本身成为新的捕获基准，因此 PiP 可以切成该区域自己的宽高比。
+            // 上层会把 normalized 映射到当前 sourceRect；本地先复位 zoom/anchor，避免连续手势
+            // 在上层 update(state:) 回来前误用旧倍率。
+            zoom = PiPSessionState.minZoom
+            anchor = CGPoint(x: 0.5, y: 0.5)
             pendingZoom = nil
-            onRequestZoom?(result.0, result.1)
+            pendingPan = .zero
+            onRequestSelection?(normalized)
             return
         }
 

--- a/Sources/my-window-pip/PiPSession.swift
+++ b/Sources/my-window-pip/PiPSession.swift
@@ -12,6 +12,9 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     /// 捕获基准矩形（源坐标系、左上原点、逻辑点），缩放平移都在其内部进行
     private var baseRect: CGRect
+    /// Cmd 框选后固定下来的子区域；后续滚轮缩放/平移在这个区域内部继续工作。
+    /// resetZoom() 会清掉它并恢复完整 baseRect。
+    private var selectedBaseRect: CGRect? = nil
     private var sourcePixelSize: CGSize
 
     private let engine = CaptureEngine()
@@ -23,14 +26,22 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     // 运行期辅助状态
     private var isAutoHidden = false
-    /// 自动隐藏淡出后的「临时唤回」原因：按住 ⌥，或鼠标停在顶栏热区
-    private enum PeekReason { case option, bar }
+    /// 自动隐藏淡出后的「临时唤回」原因：按住 ⌥、按住 ⌘ 框选缩放、边缘 resize，或顶栏热区。
+    private enum PeekReason: Equatable { case option, commandZoom, resize, bar }
     private var peekReason: PeekReason?
     private var isPeeking: Bool { peekReason != nil }
+    /// AppKit live resize 期间锁住可交互状态；鼠标拖出原 frame 也不能重新变成 click-through。
+    private var isLiveResizing = false
     private var idleThrottled = false
     private var reconnectAttempt = 0
     private var reconnectWork: DispatchWorkItem?
     private var probeTimer: Timer?
+    /// 创建会话时记录的源 owner PID，用于防止 CGWindowID 被复用后误认成原窗口。
+    private var sourcePID: pid_t?
+    /// 生命周期查询可能包含同步 AX IPC；只允许低频后台探测，主线程只应用结果。
+    private var isSourceProbeInFlight = false
+    /// 离屏后最多主动 retarget/restart 一次；若 SCK 仍不供帧则冻帧等待，避免重启循环。
+    private var offscreenRetargetAttempted = false
     private var geometryRecheckWork: DispatchWorkItem?
     private var hiddenAutoCloseTimer: Timer?
     private var occlusionObserver: NSObjectProtocol?
@@ -45,6 +56,11 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     private static let hiddenAutoCloseSeconds: TimeInterval = 60
     private static let maxReconnectAttempts = 3
+    private static let sourceProbeQueue = DispatchQueue(
+        label: "com.ljzxzxl.mywindowpip.source-health",
+        qos: .utility,
+        attributes: .concurrent
+    )
     /// 恢复后再确认一次几何的延时（要大于 `ShareableContentStore` 的 1 秒 TTL）
     private static let geometryRecheckDelay: TimeInterval = 1.2
     /// 标题按需刷新的最小间隔：挡住悬停抖动与菜单反复开合
@@ -64,11 +80,16 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         )
         baseRect = request.baseSourceRect
         sourcePixelSize = request.sourcePixelSize
+        sourcePID = request.source.windowID.flatMap { SourceWindowActivator.ownerPID(of: $0) }
         idleDetector = IdleDetector()
 
         let prefs = Preferences.shared
-        let width = prefs.preferredWidth(for: request.source.preferenceKey)
-            ?? min(max(request.sourcePointSize.width / 2, 320), 640)
+        let width = Geo.initialPiPWidth(
+            sourceSize: request.sourcePointSize,
+            rememberedWidth: prefs.preferredWidth(for: request.source.preferenceKey),
+            screenSizes: NSScreen.screens.map { $0.frame.size },
+            isWindowSource: request.source.windowID != nil
+        )
         windowController = PiPWindowController(
             title: request.source.displayTitle,
             aspect: request.sourcePointSize,
@@ -209,9 +230,32 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         windowController.update(state: state)
     }
 
-    func resetZoom() {
+    /// Cmd 框选后，选区本身成为新的捕获基准，因此 PiP 也切换成选区宽高比。
+    /// normalizedRect 是当前可见 sourceRect 内的左上原点归一化矩形。
+    func applySelection(_ normalizedRect: CGRect) {
+        let visible = currentVisibleSourceRect()
+        guard visible.width > 1, visible.height > 1 else { return }
+        guard normalizedRect.width > 0.02, normalizedRect.height > 0.02,
+              let selected = Geo.sourceRect(
+                  fromNormalizedVisibleRect: normalizedRect,
+                  within: visible
+              ) else { return }
+
+        selectedBaseRect = selected
+        state.hasSelectionCrop = true
         state.zoom = 1
         state.anchor = CGPoint(x: 0.5, y: 0.5)
+        windowController.setAspect(selected.size)
+        retune(reason: "框选区域 \(Int(selected.width))×\(Int(selected.height))")
+        windowController.update(state: state)
+    }
+
+    func resetZoom() {
+        selectedBaseRect = nil
+        state.hasSelectionCrop = false
+        state.zoom = 1
+        state.anchor = CGPoint(x: 0.5, y: 0.5)
+        windowController.setAspect(baseRect.size)
         retune(reason: "重置画面缩放")
         windowController.update(state: state)
     }
@@ -243,9 +287,10 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
             near: nil, duration: 3.0
         )
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+            let modifiers = NSEvent.modifierFlags
             guard let self, !self.isClosed, self.state.autoHide, !self.state.isHidden,
                   HoverMonitor.shared.currentHovered() == self.id,
-                  !NSEvent.modifierFlags.contains(.option) else { return }
+                  !modifiers.contains(.option), !modifiers.contains(.command) else { return }
             self.beginAutoHide()
         }
     }
@@ -308,16 +353,24 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     // MARK: - 捕获
 
+    private var activeBaseRect: CGRect { selectedBaseRect ?? baseRect }
+
+    /// 当前真正可见的源坐标矩形。与 `currentSourceRect()` 不同，它从不返回 `.zero`，
+    /// 因此可用于把下一次框选精确映射回源坐标。
+    private func currentVisibleSourceRect() -> CGRect {
+        Geo.sourceRect(zoom: state.zoom, anchor: state.anchor, full: activeBaseRect)
+    }
+
     private func currentSourceRect() -> CGRect {
-        // 整窗 + 未放大时不下发裁剪框：`.zero` 让 SCK 直接给整个窗口内容。
-        // 这样即使 baseRect 没能及时跟上窗口尺寸（例如调度中心期间采样到被总览变换的
-        // 矩形），画面也只是宽高比暂时不准，不会被裁成窗口左上角局部。
-        if case .window = state.source,
+        // 整窗 + 未放大 + 没有框选基准时不下发裁剪框：`.zero` 让 SCK 直接给整个窗口内容。
+        // 一旦用户框选了任意区域（selectedBaseRect != nil），即使 zoom 回到 1 也必须保留该 crop。
+        if selectedBaseRect == nil,
+           case .window = state.source,
            state.zoom <= PiPSessionState.minZoom + 0.001,
            abs(baseRect.minX) < 0.5, abs(baseRect.minY) < 0.5 {
             return .zero
         }
-        return Geo.sourceRect(zoom: state.zoom, anchor: state.anchor, full: baseRect)
+        return currentVisibleSourceRect()
     }
 
     private func makeConfiguration(fps: Int? = nil) -> SCStreamConfiguration {
@@ -427,10 +480,16 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         guard isFullWindow else { return }   // 窗口内的区域捕获不跟随窗口尺寸变化
         guard let size = trustedSize(of: window) else { return }
         guard abs(baseRect.width - size.width) > 1 || abs(baseRect.height - size.height) > 1 else { return }
-        baseRect = CGRect(origin: .zero, size: size)
+        let oldBase = baseRect
+        let newBase = CGRect(origin: .zero, size: size)
+        if let selectedBaseRect {
+            self.selectedBaseRect = Geo.remap(selectedBaseRect, from: oldBase, to: newBase)
+            state.hasSelectionCrop = self.selectedBaseRect != nil
+        }
+        baseRect = newBase
         let scale = ShareableContentStore.shared.backingScale(of: window)
         sourcePixelSize = CGSize(width: size.width * scale, height: size.height * scale)
-        windowController.setAspect(size)
+        windowController.setAspect((selectedBaseRect ?? baseRect).size)
         state.anchor = Geo.clampAnchor(state.anchor, zoom: state.zoom)
     }
 
@@ -490,6 +549,8 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         }
         DispatchQueue.main.async { [weak self] in
             guard let self, !self.isClosed else { return }
+            // 任何真实帧恢复都说明刚才的离屏 retarget 有效；允许下一次独立 stall 再尝试一次。
+            self.offscreenRetargetAttempted = false
             if case .streaming = self.runtimeState {} else if !self.state.isPaused {
                 self.update(runtimeState: .streaming)
                 self.reconnectAttempt = 0
@@ -515,8 +576,8 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     func captureDidStall() {
         guard !isClosed, !state.isPaused, !state.isHidden, !isAutoHidden else { return }
         windowController.recordRendererEvent("capture.stall no-valid-frame")
-        // 没有新帧通常意味着源窗口被最小化或所在 Space 不可见
-        update(runtimeState: .waitingForSource)
+        // stall 只表示 transport 没有帧，不能直接推导 minimized/closed。
+        update(runtimeState: .sourceOffscreen)
         startProbeTimer()
     }
 
@@ -542,28 +603,86 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     }
 
     private func probeSource() {
-        guard !isClosed else { return }
+        guard !isClosed, !isSourceProbeInFlight else { return }
         switch state.source {
         case let .window(windowID, _, _, _):
-            ShareableContentStore.shared.window(id: windowID) { [weak self] window in
-                guard let self, !self.isClosed else { return }
-                if let window, window.isOnScreen {
-                    Log.debug("源窗口已恢复，重启流")
-                    self.probeTimer?.invalidate()
-                    self.probeTimer = nil
-                    self.syncBaseRectIfNeeded(with: window)
-                    self.engine.retarget(CaptureEngine.filter(for: window))
-                    self.restartCapture(reason: "源窗口恢复")
-                    self.update(runtimeState: .streaming)
-                    // 恢复瞬间可能落在退出总览的动画中间态，稍后再确认一次几何
-                    self.scheduleGeometryRecheck()
-                } else if window == nil {
-                    self.attemptRematch()
+            isSourceProbeInFlight = true
+            let expectedPID = sourcePID
+            Self.sourceProbeQueue.async { [weak self] in
+                let observation = SourceWindowActivator.lifecycleObservation(
+                    of: windowID,
+                    expectedPID: expectedPID
+                )
+                let health = classifySourceWindowHealth(observation)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, !self.isClosed else { return }
+                    self.isSourceProbeInFlight = false
+                    self.applySourceHealth(health, windowID: windowID)
                 }
             }
         case .region:
             restartCapture(reason: "区域捕获恢复")
         }
+    }
+
+    /// 主线程应用后台生命周期探测结果。只有 SCK 本身需要 `SCWindow` 时才查询缓存。
+    private func applySourceHealth(_ health: SourceWindowHealth, windowID: CGWindowID) {
+        switch health {
+        case .onScreen:
+            offscreenRetargetAttempted = false
+            ShareableContentStore.shared.window(id: windowID) { [weak self] window in
+                guard let self, !self.isClosed, let window else { return }
+                self.resumeWindowCapture(
+                    window,
+                    reason: "源窗口回到当前 Space",
+                    syncGeometry: true,
+                    recheckGeometry: true
+                )
+            }
+
+        case .offScreenAlive:
+            update(runtimeState: .sourceOffscreen)
+            guard !offscreenRetargetAttempted else { return }
+            offscreenRetargetAttempted = true
+            // 全 Space 枚举能拿到新的 SCWindow 快照时，主动 retarget 一次。部分应用/SCK 版本可由此
+            // 恢复跨 Space 实时帧；若仍不供帧则保持最后一帧并继续 probe，不做循环重启。
+            ShareableContentStore.shared.window(id: windowID) { [weak self] window in
+                guard let self, !self.isClosed, let window else { return }
+                self.resumeWindowCapture(
+                    window,
+                    reason: "源窗口离屏 retarget",
+                    syncGeometry: false,
+                    recheckGeometry: false
+                )
+            }
+
+        case .minimized:
+            update(runtimeState: .minimized)
+
+        case .missing:
+            attemptRematch()
+
+        case .unknown:
+            update(runtimeState: .sourceOffscreen)
+        }
+    }
+
+    private func resumeWindowCapture(
+        _ window: SCWindow,
+        reason: String,
+        syncGeometry: Bool,
+        recheckGeometry: Bool
+    ) {
+        Log.debug("\(reason)，重建捕获目标")
+        probeTimer?.invalidate()
+        probeTimer = nil
+        // 其它 Space 的 SCWindow 快照只用于构造新的 content filter；它的 frame 不能用来更新
+        // baseRect / aspect，否则离屏几何可能污染裁剪与窗口比例，造成黑边和后续 zoom 错位。
+        if syncGeometry { syncBaseRectIfNeeded(with: window) }
+        engine.retarget(CaptureEngine.filter(for: window))
+        restartCapture(reason: reason)
+        update(runtimeState: .streaming)
+        if recheckGeometry { scheduleGeometryRecheck() }
     }
 
     private func scheduleReconnect() {
@@ -603,22 +722,38 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
                 return
             }
             Log.info("已重新匹配到源窗口：\(ShareableContentStore.shared.displayTitle(for: window))")
-            self.state.source = ShareableContentStore.shared.captureSource(for: window)
-            // 重新匹配同样不能照抄可能被总览变换过的尺寸
-            let size = self.trustedSize(of: window) ?? self.baseRect.size
-            self.baseRect = CGRect(origin: .zero, size: size)
-            let scale = ShareableContentStore.shared.backingScale(of: window)
-            self.sourcePixelSize = CGSize(width: size.width * scale, height: size.height * scale)
-            self.windowController.setTitle(self.state.source.displayTitle)
-            self.windowController.setAspect(size)
-            self.probeTimer?.invalidate()
-            self.probeTimer = nil
-            self.reconnectAttempt = 0
-            self.windowController.recordRendererEvent("capture.rematch source=\(self.state.source.displayTitle)")
-            self.windowController.prepareForCaptureDiscontinuity("源窗口重新匹配")
-            self.engine.stop()
-            self.startStream(filter: CaptureEngine.filter(for: window))
+            self.adoptRematchedWindow(window, reason: "源窗口重新匹配")
         }
+    }
+
+    private func adoptRematchedWindow(_ window: SCWindow, reason: String) {
+        state.source = ShareableContentStore.shared.captureSource(for: window)
+        sourcePID = window.owningApplication?.processID
+        offscreenRetargetAttempted = false
+        // 重匹配同样不能照抄可能被总览变换过的尺寸。若用户已框选区域，按旧基准的归一化位置
+        // 映射到新窗口尺寸，保持选区比例与相对位置，而不是重启后突然恢复整窗。
+        let size = trustedSize(of: window) ?? baseRect.size
+        let oldBase = baseRect
+        let newBase = CGRect(origin: .zero, size: size)
+        if let selectedBaseRect {
+            self.selectedBaseRect = Geo.remap(selectedBaseRect, from: oldBase, to: newBase)
+            state.hasSelectionCrop = self.selectedBaseRect != nil
+        }
+        baseRect = newBase
+        let scale = ShareableContentStore.shared.backingScale(of: window)
+        sourcePixelSize = CGSize(width: size.width * scale, height: size.height * scale)
+        windowController.setTitle(state.source.displayTitle)
+        windowController.setAspect((selectedBaseRect ?? baseRect).size)
+        probeTimer?.invalidate()
+        probeTimer = nil
+        reconnectWork?.cancel()
+        reconnectWork = nil
+        reconnectAttempt = 0
+        windowController.recordRendererEvent("capture.rematch source=\(state.source.displayTitle) reason=\(reason)")
+        // 计划性 flush 保留 displayed image；直到新 stream 第一帧进来，用户仍看到旧源最后一帧。
+        windowController.prepareForCaptureDiscontinuity(reason)
+        engine.stop()
+        startStream(filter: CaptureEngine.filter(for: window))
     }
 
     private func handleSourceMissing() {
@@ -654,6 +789,10 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
                 guard let self, !self.isClosed, !self.state.isHidden else { return nil }
                 return self.windowController.barScreenFrame
             },
+            resizeZoneThicknessProvider: { [weak self] in
+                guard let self, !self.isClosed, !self.state.isHidden, self.state.autoHide else { return 0 }
+                return self.windowController.autoHideResizeHotZoneThickness
+            },
             onChange: { [weak self] hover in
                 self?.handleHover(hover)
             }
@@ -662,9 +801,12 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     /// 悬停状态处理。
     ///
-    /// 自动隐藏开启后浮窗会淡出并点击穿透，此时它收不到任何鼠标事件——所以留了两条唤回通道：
-    /// - **鼠标停在顶栏热区**：顶栏区域始终可操作（点按钮、按住拖动、右键），画面区域仍然穿透
-    /// - **按住 ⌥**：在画面区域也能把整窗临时唤回
+    /// 自动隐藏开启后浮窗会淡出并点击穿透，此时它收不到任何鼠标事件——所以靠 HoverMonitor
+    /// 的零权限轮询提供四条唤回通道：
+    /// - **按住 ⌘**：恢复内容区命中，使 Cmd 拖拽框选仍能工作；不弹控制条
+    /// - **按住 ⌥**：在画面区域把整窗临时唤回
+    /// - **鼠标靠近四边/四角**：恢复系统 resize 命中；不弹控制条
+    /// - **鼠标停在顶栏热区**：顶栏区域可操作（点按钮、按住拖动、右键）
     /// 另有一条保底出口在菜单栏的每会话子菜单里。
     private func handleHover(_ hover: HoverState) {
         guard !isClosed else { return }
@@ -679,16 +821,24 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
             return
         }
 
-        guard hover.isHovering else {
-            endAutoHide()
+        // live resize 已经开始后不再相信鼠标是否还落在旧 frame 内；拖到窗外也必须保持可交互。
+        if isLiveResizing {
+            beginPeek(.resize)
             return
         }
 
-        if hover.isOverHotZone {
-            beginPeek(.bar)           // 热区优先于 ⌥
-        } else if hover.optionHeld {
+        switch autoHideHoverIntent(for: hover) {
+        case .leave:
+            endAutoHide()
+        case .resize:
+            beginPeek(.resize)
+        case .bar:
+            beginPeek(.bar)
+        case .command:
+            beginPeek(.commandZoom)
+        case .option:
             beginPeek(.option)
-        } else {
+        case .fade:
             beginAutoHide()
         }
     }
@@ -711,11 +861,17 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
         isAutoHidden = true
         windowController.setAlpha(1, animated: true)
         windowController.setClickThrough(false)
-        windowController.setControlsVisible(true)
+        windowController.setControlsVisible(reason == .option || reason == .bar)
         if !state.isPaused, !state.isHidden { resumeCapture(reason: "自动隐藏临时唤回") }
         switch reason {
         case .option:
             windowController.showHint(L.t("松开 ⌥ 恢复透明", "Release ⌥ to fade again"), near: nil)
+        case .commandZoom:
+            // 不弹 hint / 控制条，避免挡住内容区的 Cmd 框选缩放手势。
+            windowController.showHint(nil, near: nil)
+        case .resize:
+            // 边缘只恢复系统 resize 命中，不弹控制条/提示，避免盖住用户正在抓的边角。
+            windowController.showHint(nil, near: nil)
         case .bar:
             windowController.showHint(L.t("移出顶栏后会重新淡出", "Leave the top bar to fade again"),
                                       near: nil, duration: 2.0)
@@ -776,6 +932,8 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
 
     func pipRequestZoom(_ zoom: CGFloat, anchor: CGPoint) { applyZoom(zoom, anchor: anchor) }
 
+    func pipRequestSelection(_ normalizedRect: CGRect) { applySelection(normalizedRect) }
+
     func pipRequestPan(by delta: CGSize) {
         guard state.zoom > 1.001 else { return }
         state.anchor = Geo.anchor(state.anchor, pannedBy: delta, zoom: state.zoom)
@@ -783,6 +941,20 @@ final class PiPSession: NSObject, CaptureEngineDelegate, PiPWindowDelegate {
     }
 
     func pipRequestZoomReset() { resetZoom() }
+
+    func pipWillStartLiveResize() {
+        guard !isClosed else { return }
+        isLiveResizing = true
+        if state.autoHide { beginPeek(.resize) }
+    }
+
+    func pipDidEndLiveResize() {
+        guard !isClosed else { return }
+        isLiveResizing = false
+        guard state.autoHide else { return }
+        // 立即按当前鼠标位置恢复 fade / bar / edge 状态，不等下一次轮询状态变化。
+        handleHover(HoverMonitor.shared.currentState(for: id))
+    }
 
     func pipDidResize(pointSize: CGSize, scale: CGFloat) {
         guard !isClosed else { return }

--- a/Sources/my-window-pip/PiPWindowController.swift
+++ b/Sources/my-window-pip/PiPWindowController.swift
@@ -182,6 +182,8 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
     private static let hintMinWindowAlpha: CGFloat = 0.99
     /// 顶栏热区在控制条上下各放宽的距离（`barScreenFrame`）
     private static let barHotZoneInset: CGFloat = 4
+    /// 自动隐藏时边缘 resize 热区厚度；同时覆盖窗内/窗外，让鼠标靠近边角即可恢复命中。
+    private static let resizeHotZoneThickness: CGFloat = 10
 
     // MARK: - 对外
 
@@ -198,6 +200,9 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
     var backingScale: CGFloat { panel.screen?.backingScaleFactor ?? panel.backingScaleFactor }
 
     var frameOrigin: CGPoint { panel.frame.origin }
+
+    /// HoverMonitor 用的边缘 resize 热区厚度。
+    var autoHideResizeHotZoneThickness: CGFloat { Self.resizeHotZoneThickness }
 
     /// 供 HoverMonitor 校验鼠标是否落在本浮窗上
     var isHoveringMouse: Bool {
@@ -391,6 +396,9 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
         // 手势回调 → delegate（窗口层不做任何状态决策）
         contentView.onRequestZoom = { [weak self] zoom, anchor in
             self?.delegate?.pipRequestZoom(zoom, anchor: anchor)
+        }
+        contentView.onRequestSelection = { [weak self] normalizedRect in
+            self?.delegate?.pipRequestSelection(normalizedRect)
         }
         contentView.onRequestPan = { [weak self] delta in
             self?.delegate?.pipRequestPan(by: delta)
@@ -702,7 +710,7 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
         switch newState {
         case .sourceLost, .permissionDenied, .failed:
             contentView.flushAndReset()
-        case .streaming, .paused, .waitingForSource, .reconnecting:
+        case .streaming, .paused, .sourceOffscreen, .minimized, .waitingForSource, .reconnecting:
             break
         }
         refreshMenu()
@@ -801,6 +809,16 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
     }
 
     // MARK: - NSWindowDelegate
+
+    func windowWillStartLiveResize(_ notification: Notification) {
+        delegate?.pipWillStartLiveResize()
+    }
+
+    func windowDidEndLiveResize(_ notification: Notification) {
+        delegate?.pipDidEndLiveResize()
+        // 最后一帧尺寸也要上报，避免 debounce work 在拖动结束前被覆盖。
+        scheduleResizeNotify()
+    }
 
     func windowDidResize(_ notification: Notification) {
         // 窗口尺寸变了：提示条要按新的内容区重新 clamp（控制条自己走 autoresizing）
@@ -966,11 +984,18 @@ final class PiPWindowController: NSObject, NSWindowDelegate, NSMenuDelegate {
         pauseItem.title = paused ? L.t("继续", "Resume") : L.t("暂停", "Pause")
 
         let zoom = state?.zoom ?? 1
-        zoomResetItem.title = zoom > 1.01
-            ? L.t("复位缩放（当前 \(String(format: "%.1f", zoom))×）",
-                  "Reset Zoom (now \(String(format: "%.1f", zoom))×)")
-            : L.t("复位缩放", "Reset Zoom")
-        zoomResetItem.isEnabled = zoom > 1.01
+        let cropped = state?.hasSelectionCrop ?? false
+        if zoom > 1.01 {
+            zoomResetItem.title = L.t(
+                "复位缩放（当前 \(String(format: "%.1f", zoom))×）",
+                "Reset Zoom (now \(String(format: "%.1f", zoom))×)"
+            )
+        } else if cropped {
+            zoomResetItem.title = L.t("恢复完整画面与原始比例", "Restore Full Frame & Aspect Ratio")
+        } else {
+            zoomResetItem.title = L.t("复位缩放", "Reset Zoom")
+        }
+        zoomResetItem.isEnabled = zoom > 1.01 || cropped
 
         autoHideItem.state = (state?.autoHide ?? false) ? .on : .off
         idleItem.state = (state?.idleDetection ?? true) ? .on : .off

--- a/Sources/my-window-pip/PlaceholderView.swift
+++ b/Sources/my-window-pip/PlaceholderView.swift
@@ -115,7 +115,7 @@ final class PlaceholderView: NSView {
     func update(runtimeState: SessionRuntimeState, source: CaptureSource) {
         self.runtimeState = runtimeState
 
-        guard runtimeState != .streaming else {
+        guard runtimeState != .streaming, runtimeState != .sourceOffscreen else {
             setVisible(false, animated: true)
             return
         }
@@ -149,6 +149,17 @@ final class PlaceholderView: NSView {
                 symbols: ["pause.circle"],
                 title: L.t("已暂停", "Paused"),
                 subtitle: L.t("点按浮窗或控制条继续", "Click the window or the controls to resume")
+            )
+
+        case .sourceOffscreen:
+            return Content(symbols: [], title: "", subtitle: "")
+
+        case .minimized:
+            return Content(
+                symbols: ["arrow.down.right.and.arrow.up.left.circle"],
+                title: L.t("源窗口已最小化", "Source window minimized"),
+                subtitle: L.t("恢复「\(source.displayTitle)」后会自动继续",
+                              "Restore \(source.displayTitle) to resume automatically")
             )
 
         case .waitingForSource:

--- a/Sources/my-window-pip/Preferences.swift
+++ b/Sources/my-window-pip/Preferences.swift
@@ -76,6 +76,21 @@ enum KeyCodeNames {
     }
 }
 
+/// Chromium / Electron 源应用的已验证离屏渲染兼容策略。
+enum ChromiumCompatibilityMode: String, CaseIterable {
+    case ask
+    case automatic
+    case off
+
+    var label: String {
+        switch self {
+        case .ask: return L.t("询问", "Ask")
+        case .automatic: return L.t("自动", "Automatic")
+        case .off: return L.t("关闭", "Off")
+        }
+    }
+}
+
 /// UserDefaults 封装。所有偏好读写唯一入口。
 final class Preferences {
     static let shared = Preferences()
@@ -98,6 +113,7 @@ final class Preferences {
         static let showsCursor = "showsCursor"
         static let hasSeenOnboarding = "hasSeenOnboarding"
         static let clickToActivateSource = "clickToActivateSource"
+        static let chromiumCompatibilityMode = "chromiumCompatibilityMode"
     }
 
     private init() {
@@ -111,6 +127,7 @@ final class Preferences {
             K.showsCursor: false,
             K.hasSeenOnboarding: false,
             K.clickToActivateSource: true,
+            K.chromiumCompatibilityMode: ChromiumCompatibilityMode.ask.rawValue,
         ])
     }
 
@@ -189,6 +206,16 @@ final class Preferences {
     var clickToActivateSource: Bool {
         get { d.bool(forKey: K.clickToActivateSource) }
         set { d.set(newValue, forKey: K.clickToActivateSource) }
+    }
+
+    /// 对已验证 Chromium / Electron 源应用的兼容重启策略。
+    var chromiumCompatibilityMode: ChromiumCompatibilityMode {
+        get {
+            ChromiumCompatibilityMode(
+                rawValue: d.string(forKey: K.chromiumCompatibilityMode) ?? ""
+            ) ?? .ask
+        }
+        set { d.set(newValue.rawValue, forKey: K.chromiumCompatibilityMode) }
     }
 
     // MARK: - 热键

--- a/Sources/my-window-pip/SessionStore.swift
+++ b/Sources/my-window-pip/SessionStore.swift
@@ -60,6 +60,10 @@ final class SessionStore {
 
     /// 画中画指定窗口（菜单栏选窗路径）
     func pip(window: SCWindow) {
+        pip(window: window, checkCompatibility: true, checkSoftLimit: true)
+    }
+
+    private func pip(window: SCWindow, checkCompatibility: Bool, checkSoftLimit: Bool) {
         guard Permissions.ensureScreenRecording() else { return }
 
         // 去重：同一个窗口已经有浮窗了，就把它提到最前并高亮提示
@@ -68,12 +72,18 @@ final class SessionStore {
             existing.flashHighlight()
             return
         }
-        guard confirmIfOverLimit() else { return }
+        if checkSoftLimit, !confirmIfOverLimit() { return }
+        if checkCompatibility, handleCompatibilityIfNeeded(for: window) { return }
 
+        _ = createWindowSession(window)
+    }
+
+    @discardableResult
+    private func createWindowSession(_ window: SCWindow) -> PiPSession? {
         let store = ShareableContentStore.shared
         let source = store.captureSource(for: window)
         let size = window.frame.size
-        guard size.width > 1, size.height > 1 else { return }
+        guard size.width > 1, size.height > 1 else { return nil }
 
         let request = SessionRequest(
             source: source,
@@ -84,8 +94,98 @@ final class SessionStore {
             autoHide: Preferences.shared.autoHideDefault,
             idleDetection: Preferences.shared.idleDetectionDefault
         )
-        add(PiPSession(request: request, cascadeIndex: sessions.count))
+        let session = PiPSession(request: request, cascadeIndex: sessions.count)
+        add(session)
         Log.info("新建窗口 PiP：\(source.displayTitle) @ \(request.fps.label)")
+        return session
+    }
+
+    /// 对已验证会在 inactive Space 停止 repaint 的 Chromium / Electron 源应用提供兼容重启。
+    /// 返回 true 表示本次创建已被重启流程或用户取消接管；false 表示继续正常创建 PiP。
+    private func handleCompatibilityIfNeeded(for window: SCWindow) -> Bool {
+        guard let owner = window.owningApplication,
+              let application = NSRunningApplication(processIdentifier: owner.processID),
+              let profile = SourceAppCompatibility.profile(for: application),
+              !SourceAppCompatibility.isKnownCompatibilityLaunch(
+                  profile, pid: application.processIdentifier
+              ) else { return false }
+
+        switch Preferences.shared.chromiumCompatibilityMode {
+        case .off:
+            return false
+        case .automatic:
+            startCompatibilityRelaunch(application: application, profile: profile)
+            return true
+        case .ask:
+            break
+        }
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = L.t(
+            "\(profile.appName) 可能需要 Chromium 兼容模式",
+            "\(profile.appName) may need Chromium compatibility mode"
+        )
+        alert.informativeText = profile.isVerified
+            ? L.t(
+                "MyWindowPip 已实际验证：以 Chromium 兼容模式重新启动 \(profile.appName) 后，可以继续捕获其他 Space 中的实时更新。重启会关闭当前 \(profile.appName) 进程和该应用已有的 PiP；重启完成后不会自动重新创建 PiP，请先确认没有未保存的工作。",
+                "MyWindowPip has verified that relaunching \(profile.appName) in Chromium compatibility mode keeps live updates capturable on other Spaces. Relaunching will quit the current \(profile.appName) process and close its existing PiP windows; PiP will not be recreated automatically. Save any unfinished work first."
+            )
+            : L.t(
+                "检测到 \(profile.appName) 使用 Chromium / Electron runtime。兼容模式会用已知的 Chromium 后台绘制开关重新启动它，以避免其他 Space 中停止刷新。重启会关闭当前进程及该应用已有的 PiP，完成后不会自动重新创建，请先确认没有未保存的工作。",
+                "\(profile.appName) appears to use a Chromium / Electron runtime. Compatibility mode relaunches it with the known Chromium background-rendering switch so it can keep repainting on other Spaces. Existing PiP windows for the app are closed and are not recreated automatically. Save any unfinished work first."
+            )
+        alert.addButton(withTitle: L.t("以 Chromium 兼容模式重启", "Relaunch in Chromium Compatibility Mode"))
+        alert.addButton(withTitle: L.t("直接创建 PiP", "Create PiP Anyway"))
+        alert.addButton(withTitle: L.t("取消", "Cancel"))
+        NSApp.activate(ignoringOtherApps: true)
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            startCompatibilityRelaunch(application: application, profile: profile)
+            return true
+        case .alertSecondButtonReturn:
+            return false
+        default:
+            return true
+        }
+    }
+
+    private func startCompatibilityRelaunch(
+        application: NSRunningApplication,
+        profile: SourceAppCompatibility.Profile
+    ) {
+        // 源应用重启会让旧 windowID 全部失效；与其在源应用恢复时自动把 PiP 接回并挡住
+        // 新窗口左上角，不如在重启前主动关闭该应用的窗口 PiP。重启成功后由用户按需重新创建。
+        closeWindowSessions(bundleID: profile.bundleID)
+        Log.info("以 Chromium 兼容模式重启源应用；已关闭现有 PiP：\(profile.appName)")
+
+        SourceAppCompatibility.restart(application: application, profile: profile) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case let .success(relaunched):
+                self.notify(
+                    title: L.t("Chromium 兼容模式已启用", "Chromium compatibility mode is active"),
+                    message: L.t(
+                        "\(profile.appName) 已重新启动（PID \(relaunched.processIdentifier)）。需要时请重新创建 PiP。",
+                        "\(profile.appName) relaunched (PID \(relaunched.processIdentifier)). Create a new PiP when you need it."
+                    )
+                )
+            case let .failure(error):
+                self.notify(
+                    title: L.t("Chromium 兼容模式重启失败", "Chromium compatibility relaunch failed"),
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    private func closeWindowSessions(bundleID: String) {
+        let matching = sessions.filter { session in
+            guard case let .window(_, sessionBundleID, _, _) = session.state.source else { return false }
+            return sessionBundleID == bundleID
+        }
+        matching.forEach { $0.close() }
     }
 
     /// 区域捕获（热键 / 菜单入口）

--- a/Sources/my-window-pip/SettingsWindowController.swift
+++ b/Sources/my-window-pip/SettingsWindowController.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-/// 设置窗口：通用 / 热键 / 增强模式 / 关于。
+/// 设置窗口：通用 / 热键 / 增强模式 / Chromium 兼容 / 关于。
 /// 全部用代码构建（无 xib），改动即时生效。
 final class SettingsWindowController: NSObject, NSWindowDelegate {
     static let shared = SettingsWindowController()
@@ -16,6 +16,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     private var clickToActivateHint: NSTextField?
     private var enhancedCheckbox: NSButton?
     private var launchAtLoginCheckbox: NSButton?
+    private var chromiumRuntimeStatusLabel: NSTextField?
 
     private let prefs = Preferences.shared
 
@@ -31,14 +32,15 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             return
         }
 
-        let tabView = NSTabView(frame: NSRect(x: 0, y: 0, width: 460, height: 330))
+        let tabView = NSTabView(frame: NSRect(x: 0, y: 0, width: 460, height: 400))
         tabView.addTabViewItem(makeTab(L.t("通用", "General"), view: makeGeneralView()))
         tabView.addTabViewItem(makeTab(L.t("热键", "Hotkeys"), view: makeHotkeyView()))
         tabView.addTabViewItem(makeTab(L.t("增强模式", "Enhanced"), view: makeEnhancedView()))
+        tabView.addTabViewItem(makeTab(L.t("Chromium 兼容", "Chromium"), view: makeChromiumCompatibilityView()))
         tabView.addTabViewItem(makeTab(L.t("关于", "About"), value: makeAboutView()))
 
         let w = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 360),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 430),
             styleMask: [.titled, .closable, .miniaturizable],
             backing: .buffered, defer: false
         )
@@ -47,7 +49,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         w.isReleasedWhenClosed = false
         w.center()
 
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 480, height: 360))
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 480, height: 430))
         tabView.frame = container.bounds.insetBy(dx: 10, dy: 10)
         tabView.autoresizingMask = [.width, .height]
         container.addSubview(tabView)
@@ -132,9 +134,9 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
 
         stack.addArrangedSubview(hint(L.t(
             "帧率建议：看终端/日志 1–5 fps；看仪表盘 10–15 fps；看视频 30–60 fps。\n"
-                + "自动隐藏淡出后浮窗会点击穿透，此时按住 ⌥ 可临时唤回，或从菜单栏的浮窗子菜单里关掉。",
+                + "自动隐藏淡出后浮窗会点击穿透：按住 ⌥ 可临时唤回；按住 ⌘ 可直接框选放大；也可从菜单栏的浮窗子菜单里关掉。",
             "Suggested: 1–5 fps for terminals and logs, 10–15 fps for dashboards, 30–60 fps for video.\n"
-                + "A faded PiP window is click-through — hold ⌥ to peek, or turn auto-hide off from its menu bar submenu."
+                + "A faded PiP window is click-through: hold ⌥ to peek, or hold ⌘ to drag-select a zoom region; you can also disable auto-hide from its menu bar submenu."
         )))
         return wrap(stack)
     }
@@ -222,6 +224,59 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         return wrap(stack)
     }
 
+    // MARK: - Chromium 兼容页
+
+    private func makeChromiumCompatibilityView() -> NSView {
+        let stack = verticalStack()
+        stack.addArrangedSubview(label(
+            L.t("Chromium 兼容模式", "Chromium Compatibility Mode"),
+            size: 15,
+            bold: true
+        ))
+
+        stack.addArrangedSubview(hint(L.t(
+            "部分 Chromium / Electron 应用在窗口进入其他 Space 后会主动暂停 repaint，"
+                + "导致 ScreenCaptureKit 只能保留最后一帧。兼容模式会用 Chromium 的后台绘制开关重启源应用，"
+                + "让窗口在离屏时继续绘制。",
+            "Some Chromium / Electron apps pause repainting when their windows move to another Space, "
+                + "leaving ScreenCaptureKit with only the last frame. Compatibility mode relaunches the source "
+                + "app with Chromium's background-rendering switch so it keeps rendering while offscreen."
+        )))
+
+        let chromiumPopup = NSPopUpButton()
+        for mode in ChromiumCompatibilityMode.allCases {
+            chromiumPopup.addItem(withTitle: mode.label)
+        }
+        chromiumPopup.selectItem(
+            at: ChromiumCompatibilityMode.allCases.firstIndex(of: prefs.chromiumCompatibilityMode) ?? 0
+        )
+        chromiumPopup.target = self
+        chromiumPopup.action = #selector(chromiumCompatibilityChanged(_:))
+        stack.addArrangedSubview(row(L.t("处理方式", "Behavior"), chromiumPopup))
+
+        let verifiedApps = SourceAppCompatibility.verifiedAppNames.joined(separator: ", ")
+        stack.addArrangedSubview(hint(L.t(
+            "询问：检测到 Chromium / Electron runtime 时先确认是否重启源应用。\n"
+                + "自动：检测命中后直接以兼容模式重启。\n"
+                + "关闭：不修改源应用启动方式。\n\n"
+                + "当前已人工验证：\(verifiedApps)。其它常见 Chromium / Electron 应用使用保守的 bundle 特征自动识别。",
+            "Ask: confirm before relaunching when a Chromium / Electron runtime is detected.\n"
+                + "Automatic: relaunch detected apps automatically in compatibility mode.\n"
+                + "Off: never change the source app launch mode.\n\n"
+                + "Currently verified: \(verifiedApps). Other common Chromium / Electron apps are detected conservatively from their app-bundle runtime signatures."
+        )))
+
+        let runtimeStatus = hint("")
+        chromiumRuntimeStatusLabel = runtimeStatus
+        stack.addArrangedSubview(runtimeStatus)
+
+        stack.addArrangedSubview(hint(L.t(
+            "注意：重启源应用可能中断未保存的工作。「询问」是默认且最安全的设置。兼容重启前会关闭该应用已有的 PiP，重启完成后不会自动重新创建。",
+            "Note: relaunching a source app can interrupt unsaved work. Ask is the default and safest setting. Existing PiP windows for that app are closed before relaunch and are not recreated automatically."
+        )))
+        return wrap(stack)
+    }
+
     // MARK: - 关于页
 
     private func makeAboutView() -> NSView {
@@ -275,6 +330,22 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         clickToActivateHint?.isHidden = granted || !prefs.clickToActivateSource
         enhancedCheckbox?.state = EventTapManager.shared.isEnabled ? .on : .off
         launchAtLoginCheckbox?.state = LoginItem.isEnabled ? .on : .off
+
+        let runtimeStatuses = SourceAppCompatibility.verifiedRuntimeStatuses()
+        if runtimeStatuses.isEmpty {
+            chromiumRuntimeStatusLabel?.stringValue = L.t(
+                "当前没有已验证的 Chromium 兼容应用在运行。",
+                "No verified Chromium compatibility app is currently running."
+            )
+        } else {
+            let lines = runtimeStatuses.map { status in
+                let state = status.isCompatible
+                    ? L.t("兼容参数已生效", "compatibility argument active")
+                    : L.t("普通启动", "normal launch")
+                return "\(status.appName) · PID \(status.pid) · \(state)"
+            }
+            chromiumRuntimeStatusLabel?.stringValue = lines.joined(separator: "\n")
+        }
     }
 
     private func reloadHotkeys() {
@@ -316,6 +387,11 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     @objc private func clickToActivateChanged(_ sender: NSButton) {
         prefs.clickToActivateSource = sender.state == .on
         refreshDynamicStates()
+    }
+
+    @objc private func chromiumCompatibilityChanged(_ sender: NSPopUpButton) {
+        let index = max(0, min(sender.indexOfSelectedItem, ChromiumCompatibilityMode.allCases.count - 1))
+        prefs.chromiumCompatibilityMode = ChromiumCompatibilityMode.allCases[index]
     }
 
     @objc private func launchAtLoginChanged(_ sender: NSButton) {

--- a/Sources/my-window-pip/ShareableContentStore.swift
+++ b/Sources/my-window-pip/ShareableContentStore.swift
@@ -19,8 +19,9 @@ struct WindowGroup {
 /// 设计要点：
 /// - 单次查询要数十毫秒，菜单栏点开时必须立即有数据，因此做 1 秒 TTL 缓存；
 ///   过期时先返回旧值再触发后台刷新（getter 不阻塞）。
-/// - 缓存分三份：`candidates`（可作为 PiP 源，已过滤）、`all`（不含自身 App 的全部窗口，
-///   供按 ID 精确查找）、`own`（自身 App 的窗口，区域捕获时要排除，防止镜中镜）。
+/// - 枚举覆盖全部 Space；缓存分三份：`candidates`（可作为 PiP 源，已过滤）、`all`
+///   （不含自身 App 的全部窗口，供按 ID 精确查找）、`own`（自身 App 的窗口，区域捕获时
+///   要排除，防止镜中镜）。前台窗口入口再按实时 onscreen + WindowServer 层级收窄。
 /// - 对外语义是「主线程访问」；但 `cachedWindow(id:)` 属于高频路径，可能在捕获队列上被调用，
 ///   因此所有缓存读写都用一把锁保护，跨线程读取安全（读到的是某一时刻的快照）。
 ///
@@ -105,8 +106,10 @@ final class ShareableContentStore: @unchecked Sendable {
         // SCShareableContent 的查询是 async throws，包在 Task 里执行，结果切回主线程处理。
         Task {
             do {
+                // 菜单、按 ID 存活检查和断线恢复都必须能看到其它 Space / 最小化窗口。
+                // 是否位于当前前台只属于 `frontmostWindow` 的选择条件，不能在枚举源头过滤。
                 let content = try await SCShareableContent.excludingDesktopWindows(
-                    true, onScreenWindowsOnly: true
+                    true, onScreenWindowsOnly: false
                 )
                 let snapshot = ContentSnapshot(content)
                 DispatchQueue.main.async { self.finishRefresh(.success(snapshot)) }
@@ -176,7 +179,7 @@ final class ShareableContentStore: @unchecked Sendable {
 
     // MARK: - 查询接口
 
-    /// 前台 App 的主窗口：pid 匹配 + `windowLayer == 0` + 在屏 + 尺寸 > 80 + 面积最大。
+    /// 当前真正位于前台的主窗口：前台 App pid + WindowServer 前后顺序 + onscreen 普通层窗口。
     func frontmostWindow(completion: @escaping (SCWindow?) -> Void) {
         withFreshCache { [weak self] in
             completion(self?.frontmostWindowFromCache())
@@ -261,18 +264,49 @@ final class ShareableContentStore: @unchecked Sendable {
 
     private func frontmostWindowFromCache() -> SCWindow? {
         let windows = withLock { candidatesCache }
-        // 自身在前台（例如打开了设置窗口）时不按 pid 匹配，退化为「最前面的可捕获窗口」
-        var pid = NSWorkspace.shared.frontmostApplication?.processIdentifier
-        if pid == Self.ownProcessID { pid = nil }
+        // WindowServer ID 按约定唯一；覆盖式构造仍可避免异常重复数据导致进程崩溃。
+        var byID: [CGWindowID: SCWindow] = [:]
+        for window in windows { byID[window.windowID] = window }
 
-        if let pid {
-            let matched = windows.filter { window in
-                guard let app = window.owningApplication, app.processID == pid else { return false }
-                return Self.isMainLike(window)
+        // 全 Space 枚举后不能再依赖 SCK 数组顺序。CGWindowList 给出当前 onscreen 窗口的
+        // 实时前后顺序，再按 windowID 映射回 SCWindow，保证快捷键只选当前可见窗口。
+        let orderedIDs = Self.orderedOnScreenWindowIDs()
+        let orderedOnScreen = (orderedIDs ?? []).compactMap { byID[$0] }
+            .filter(Self.hasMainWindowGeometry)
+
+        let frontmostPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        if let pid = frontmostPID, pid != Self.ownProcessID {
+            let matched = orderedOnScreen.filter { $0.owningApplication?.processID == pid }
+            if !matched.isEmpty {
+                let screenSizes = NSScreen.screens.map { $0.frame.size }
+                // 全屏/最大化应用可能同时暴露多个 layer-0 surface，例如 Chrome 会有横跨全屏
+                // 但只有百来点高的辅助窗口。此时优先选覆盖屏幕主体且面积最大的窗口，确保
+                // 前台 PiP 捕获的是完整主窗口；普通多窗口场景仍保留 WindowServer z-order。
+                if let screenFilling = matched
+                    .filter({ Geo.isScreenFillingWindow(size: $0.frame.size, screenSizes: screenSizes) })
+                    .max(by: { Self.area($0) < Self.area($1) }) {
+                    return screenFilling
+                }
+                return matched[0]
             }
-            if let best = matched.max(by: { Self.area($0) < Self.area($1) }) { return best }
+            if orderedIDs == nil {
+                let fallbackMatched = windows.filter {
+                    $0.owningApplication?.processID == pid && Self.isMainLike($0)
+                }
+                let screenSizes = NSScreen.screens.map { $0.frame.size }
+                if let screenFilling = fallbackMatched
+                    .filter({ Geo.isScreenFillingWindow(size: $0.frame.size, screenSizes: screenSizes) })
+                    .max(by: { Self.area($0) < Self.area($1) }) {
+                    return screenFilling
+                }
+                return fallbackMatched.first
+            }
+            return nil
         }
-        // 兜底：SCShareableContent 的窗口按前后顺序返回，取第一个像主窗口的
+
+        // 自身在前台（例如状态栏菜单触发）时，退化为最前面的非自身可捕获窗口。
+        if let frontmost = orderedOnScreen.first { return frontmost }
+        guard orderedIDs == nil else { return nil }
         return windows.first(where: Self.isMainLike)
     }
 
@@ -323,21 +357,56 @@ final class ShareableContentStore: @unchecked Sendable {
         return false
     }
 
-    /// 是否可作为 PiP 源：尺寸够大，且不是「无标题的小浮层」。
+    /// 是否适合出现在窗口选择菜单。
+    /// 全 Space 枚举会带回后台代理和内部 surface；这里只保留用户可理解的普通窗口。
     private static func isCandidate(_ window: SCWindow) -> Bool {
+        guard window.windowLayer == 0,
+              let owner = window.owningApplication,
+              owner.processID > 0 else { return false }
+
+        let title = trimmedTitle(of: window)
+        guard let runningApp = NSRunningApplication(processIdentifier: owner.processID),
+              !runningApp.isTerminated,
+              !runningApp.isHidden else { return false }
+        switch runningApp.activationPolicy {
+        case .regular:
+            break
+        case .accessory:
+            guard window.isOnScreen, !title.isEmpty else { return false }
+        case .prohibited:
+            return false
+        @unknown default:
+            guard window.isOnScreen, !title.isEmpty else { return false }
+        }
+
         let frame = window.frame
         guard frame.width.isFinite, frame.height.isFinite else { return false }
         guard frame.width >= minWindowSide, frame.height >= minWindowSide else { return false }
-        if trimmedTitle(of: window).isEmpty, area(window) < minUntitledArea { return false }
+        if !window.isOnScreen, title.isEmpty { return false }
+        if title.isEmpty, area(window) < minUntitledArea { return false }
         return true
     }
 
     /// 像「App 主窗口」：普通层级 + 在屏 + 尺寸大于阈值。
     private static func isMainLike(_ window: SCWindow) -> Bool {
-        window.isOnScreen
-            && window.windowLayer == 0
+        window.isOnScreen && hasMainWindowGeometry(window)
+    }
+
+    /// 普通主窗口的稳定属性；是否在屏由调用方根据实时 WindowServer 信息判断。
+    private static func hasMainWindowGeometry(_ window: SCWindow) -> Bool {
+        window.windowLayer == 0
             && window.frame.width > minWindowSide
             && window.frame.height > minWindowSide
+    }
+
+    /// WindowServer 当前 onscreen 窗口的前后顺序（最前面的在前）。
+    private static func orderedOnScreenWindowIDs() -> [CGWindowID]? {
+        guard let list = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] else { return nil }
+        return list.compactMap { info in
+            (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value
+        }
     }
 
     private static func area(_ window: SCWindow) -> CGFloat {

--- a/Sources/my-window-pip/SourceAppCompatibility.swift
+++ b/Sources/my-window-pip/SourceAppCompatibility.swift
@@ -1,0 +1,381 @@
+import AppKit
+import Darwin
+
+/// 已验证 Chromium / Electron 源应用的兼容启动策略。
+///
+/// 只处理「源应用主动停止离屏 repaint」这类应用特例；CaptureEngine/PiPSession 不感知具体 App。
+enum SourceAppCompatibility {
+    struct Profile: Equatable {
+        let bundleID: String
+        let appName: String
+        let launchArguments: [String]
+        /// true = 已在本项目中实际 A/B 验证；false = 通过保守的 Chromium/Electron bundle 特征识别。
+        let isVerified: Bool
+    }
+
+    /// 文件系统探测结果拆成纯数据，便于测试而不依赖本机安装了哪些 App。
+    struct RuntimeStatus: Equatable {
+        let appName: String
+        let pid: pid_t
+        let isCompatible: Bool
+    }
+
+    struct BundleSignature: Equatable {
+        let hasElectronFramework: Bool
+        let hasElectronAsar: Bool
+        let hasRendererHelper: Bool
+        let hasResourcesPak: Bool
+        let hasICUData: Bool
+    }
+
+    enum RestartError: LocalizedError {
+        case applicationURLUnavailable
+        case terminationRejected
+        case terminationTimedOut
+        case launchFailed(String)
+        case compatibilityArgumentsNotApplied
+
+        var errorDescription: String? {
+            switch self {
+            case .applicationURLUnavailable:
+                return L.t("找不到源应用的位置", "Could not locate the source application")
+            case .terminationRejected:
+                return L.t("源应用拒绝退出", "The source application refused to quit")
+            case .terminationTimedOut:
+                return L.t("等待源应用退出超时", "Timed out waiting for the source application to quit")
+            case let .launchFailed(message):
+                return message
+            case .compatibilityArgumentsNotApplied:
+                return L.t(
+                    "源应用重新启动了，但 Chromium 兼容参数没有生效",
+                    "The source app relaunched, but the Chromium compatibility argument was not applied"
+                )
+            }
+        }
+    }
+
+    private static let compatibilityArguments = ["--disable-backgrounding-occluded-windows"]
+
+    /// 已人工 A/B 验证：ChatGPT 与 Google Chrome 都会在 inactive Space 停止普通 UI repaint，
+    /// 带该 Chromium 开关后可持续被 SCK 捕获。
+    private static let verifiedProfiles: [Profile] = [
+        Profile(
+            bundleID: "com.openai.codex",
+            appName: "ChatGPT",
+            launchArguments: compatibilityArguments,
+            isVerified: true
+        ),
+        Profile(
+            bundleID: "com.google.Chrome",
+            appName: "Google Chrome",
+            launchArguments: compatibilityArguments,
+            isVerified: true
+        ),
+    ]
+
+    /// 动态框架探测只发生在创建 PiP 时；缓存避免反复遍历大 App bundle。
+    private static var chromiumDetectionCache: [String: Bool] = [:]
+
+    static var verifiedAppNames: [String] { verifiedProfiles.map(\.appName) }
+
+    /// 设置页展示用：列出已验证应用当前主进程及兼容参数是否真实生效。
+    static func verifiedRuntimeStatuses() -> [RuntimeStatus] {
+        verifiedProfiles.compactMap { profile in
+            guard let application = NSRunningApplication.runningApplications(
+                withBundleIdentifier: profile.bundleID
+            ).first(where: { !$0.isTerminated }) else { return nil }
+            let pid = application.processIdentifier
+            return RuntimeStatus(
+                appName: profile.appName,
+                pid: pid,
+                isCompatible: isKnownCompatibilityLaunch(profile, pid: pid)
+            )
+        }
+    }
+
+    /// 仅返回明确 A/B 验证过的静态 profile，供测试/展示使用。
+    static func profile(for bundleID: String?) -> Profile? {
+        guard let bundleID else { return nil }
+        return verifiedProfiles.first { $0.bundleID == bundleID }
+    }
+
+    /// 创建 PiP 时使用：已验证应用优先；其它应用则用保守 bundle 特征识别常见 Chromium/Electron。
+    /// 这不是“所有 Electron 都一定有问题”的断言，只代表该启动开关在这类 runtime 中可用。
+    static func profile(for application: NSRunningApplication) -> Profile? {
+        guard let bundleID = application.bundleIdentifier else { return nil }
+        if let verified = profile(for: bundleID) { return verified }
+        guard let bundleURL = application.bundleURL,
+              isChromiumLikeBundle(bundleURL, cacheKey: bundleID) else { return nil }
+        return Profile(
+            bundleID: bundleID,
+            appName: application.localizedName
+                ?? bundleURL.deletingPathExtension().lastPathComponent,
+            launchArguments: compatibilityArguments,
+            isVerified: false
+        )
+    }
+
+    static func isChromiumLike(_ signature: BundleSignature) -> Bool {
+        if signature.hasElectronFramework || signature.hasElectronAsar { return true }
+        return signature.hasRendererHelper && signature.hasResourcesPak && signature.hasICUData
+    }
+
+    private static func isChromiumLikeBundle(_ bundleURL: URL, cacheKey: String) -> Bool {
+        if let cached = chromiumDetectionCache[cacheKey] { return cached }
+        let fm = FileManager.default
+        let contents = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let frameworks = contents.appendingPathComponent("Frameworks", isDirectory: true)
+        let resources = contents.appendingPathComponent("Resources", isDirectory: true)
+        let electronFramework = frameworks.appendingPathComponent("Electron Framework.framework")
+        let electronAsar = resources.appendingPathComponent("electron.asar")
+
+        var rendererHelper = false
+        var resourcesPak = false
+        var icuData = false
+        if let enumerator = fm.enumerator(
+            at: frameworks,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            for case let url as URL in enumerator {
+                switch url.lastPathComponent {
+                case let name where name.hasSuffix("Helper (Renderer).app"):
+                    rendererHelper = true
+                case "resources.pak":
+                    resourcesPak = true
+                case "icudtl.dat":
+                    icuData = true
+                default:
+                    break
+                }
+                if rendererHelper && resourcesPak && icuData { break }
+            }
+        }
+
+        let signature = BundleSignature(
+            hasElectronFramework: fm.fileExists(atPath: electronFramework.path),
+            hasElectronAsar: fm.fileExists(atPath: electronAsar.path),
+            hasRendererHelper: rendererHelper,
+            hasResourcesPak: resourcesPak,
+            hasICUData: icuData
+        )
+        let result = isChromiumLike(signature)
+        chromiumDetectionCache[cacheKey] = result
+        return result
+    }
+
+    /// 当前进程是否真的带着兼容参数运行。PID 只是缓存键，命令行才是事实来源。
+    ///
+    /// - 旧版本曾使用 `sourceCompatibility.pid.*`，这里顺带迁移；
+    /// - 浏览器自己 re-exec 导致 PID 变化时，只要参数仍在就自动更新记录；
+    /// - PID 一样但参数不在时，清掉记录，避免把普通启动误认成兼容启动。
+    static func isKnownCompatibilityLaunch(_ profile: Profile, pid: pid_t) -> Bool {
+        let defaults = UserDefaults.standard
+        let key = compatibilityPIDKey(profile.bundleID)
+        let legacyKey = legacyCompatibilityPIDKey(profile.bundleID)
+
+        let hasArguments = processHasCompatibilityArguments(pid: pid, profile: profile)
+        if hasArguments {
+            defaults.set(Int(pid), forKey: key)
+            defaults.removeObject(forKey: legacyKey)
+            return true
+        }
+
+        if defaults.integer(forKey: key) == Int(pid) {
+            defaults.removeObject(forKey: key)
+        }
+        if defaults.integer(forKey: legacyKey) == Int(pid) {
+            defaults.removeObject(forKey: legacyKey)
+        }
+        return false
+    }
+
+    /// 返回当前真正带兼容参数运行的主应用实例，并同步最新 PID 记录。
+    static func compatibleRunningApplication(_ profile: Profile) -> NSRunningApplication? {
+        for application in NSRunningApplication.runningApplications(withBundleIdentifier: profile.bundleID)
+            where !application.isTerminated {
+            if isKnownCompatibilityLaunch(profile, pid: application.processIdentifier) {
+                return application
+            }
+        }
+        return nil
+    }
+
+    static func restart(
+        application: NSRunningApplication,
+        profile: Profile,
+        completion: @escaping (Result<NSRunningApplication, Error>) -> Void
+    ) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let bundleURL = application.bundleURL else {
+            completion(.failure(RestartError.applicationURLUnavailable))
+            return
+        }
+
+        let oldPID = application.processIdentifier
+        let launchArguments = launchArgumentsByAppendingCompatibility(
+            processArguments: processArguments(pid: oldPID),
+            compatibilityArguments: profile.launchArguments
+        )
+        guard application.terminate() else {
+            completion(.failure(RestartError.terminationRejected))
+            return
+        }
+
+        waitForTermination(pid: oldPID, deadline: .now() + 8) {
+            // 直接执行 /usr/bin/open（不经过 shell），保留能读到的现有 argv，再追加兼容参数。
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+            process.arguments = ["-na", bundleURL.path, "--args"] + launchArguments
+            do {
+                try process.run()
+            } catch {
+                completion(.failure(RestartError.launchFailed(error.localizedDescription)))
+                return
+            }
+            waitForStableCompatibleApplication(
+                profile: profile,
+                deadline: .now() + 12,
+                candidatePID: nil,
+                stableTicks: 0,
+                completion: completion
+            )
+        } onTimeout: {
+            completion(.failure(RestartError.terminationTimedOut))
+        }
+    }
+
+    private static func waitForStableCompatibleApplication(
+        profile: Profile,
+        deadline: DispatchTime,
+        candidatePID: pid_t?,
+        stableTicks: Int,
+        completion: @escaping (Result<NSRunningApplication, Error>) -> Void
+    ) {
+        if let application = compatibleRunningApplication(profile) {
+            let pid = application.processIdentifier
+            let ticks = pid == candidatePID ? stableTicks + 1 : 1
+            // 连续约 1 秒保持同一主 PID 且兼容参数仍在，才认定为最终稳定进程并记录。
+            if ticks >= 4 {
+                UserDefaults.standard.set(Int(pid), forKey: compatibilityPIDKey(profile.bundleID))
+                Log.info("Chromium 兼容进程已稳定：\(profile.appName) pid=\(pid)")
+                completion(.success(application))
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                waitForStableCompatibleApplication(
+                    profile: profile,
+                    deadline: deadline,
+                    candidatePID: pid,
+                    stableTicks: ticks,
+                    completion: completion
+                )
+            }
+            return
+        }
+
+        guard DispatchTime.now() < deadline else {
+            completion(.failure(RestartError.compatibilityArgumentsNotApplied))
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            waitForStableCompatibleApplication(
+                profile: profile,
+                deadline: deadline,
+                candidatePID: nil,
+                stableTicks: 0,
+                completion: completion
+            )
+        }
+    }
+
+    private static func processHasCompatibilityArguments(pid: pid_t, profile: Profile) -> Bool {
+        guard let arguments = processArguments(pid: pid) else { return false }
+        return profile.launchArguments.allSatisfy(arguments.contains)
+    }
+
+    /// 保留当前应用原有 argv（去掉 argv[0]），再在末尾追加缺失的 Chromium 兼容参数。
+    /// 不过滤、不改写原有参数：外部脚本设置的地区、profile、proxy 等启动参数都应原样继承。
+    static func launchArgumentsByAppendingCompatibility(
+        processArguments: [String]?,
+        compatibilityArguments: [String]
+    ) -> [String] {
+        var result = processArguments.map { Array($0.dropFirst()) } ?? []
+        for argument in compatibilityArguments where !result.contains(argument) {
+            result.append(argument)
+        }
+        return result
+    }
+
+    /// 读取同一用户进程的 argv（KERN_PROCARGS2），不调用 shell/ps。
+    static func processArguments(pid: pid_t) -> [String]? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size: size_t = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0,
+              size > MemoryLayout<Int32>.size else { return nil }
+
+        var bytes = [UInt8](repeating: 0, count: size)
+        guard sysctl(&mib, u_int(mib.count), &bytes, &size, nil, 0) == 0 else { return nil }
+        if size < bytes.count { bytes.removeSubrange(size..<bytes.count) }
+        return parseProcessArgumentsBuffer(bytes)
+    }
+
+    /// KERN_PROCARGS2 缓冲解析拆成纯函数，便于单元测试。
+    static func parseProcessArgumentsBuffer(_ bytes: [UInt8]) -> [String]? {
+        guard bytes.count >= MemoryLayout<Int32>.size else { return nil }
+        let argc: Int32 = bytes.withUnsafeBytes { raw in
+            raw.loadUnaligned(as: Int32.self)
+        }
+        guard argc > 0, argc < 4096 else { return nil }
+
+        var index = MemoryLayout<Int32>.size
+        // 第一个 NUL 结尾字符串是 executable path。
+        while index < bytes.count, bytes[index] != 0 { index += 1 }
+        while index < bytes.count, bytes[index] == 0 { index += 1 }
+
+        var result: [String] = []
+        result.reserveCapacity(Int(argc))
+        while index < bytes.count, result.count < Int(argc) {
+            let start = index
+            while index < bytes.count, bytes[index] != 0 { index += 1 }
+            guard index > start else { break }
+            let slice = bytes[start..<index]
+            guard let value = String(bytes: slice, encoding: .utf8) else { return nil }
+            result.append(value)
+            while index < bytes.count, bytes[index] == 0 { index += 1 }
+        }
+        return result.count == Int(argc) ? result : nil
+    }
+
+    private static func waitForTermination(
+        pid: pid_t,
+        deadline: DispatchTime,
+        completion: @escaping () -> Void,
+        onTimeout: @escaping () -> Void
+    ) {
+        if NSRunningApplication(processIdentifier: pid) == nil {
+            completion()
+            return
+        }
+        guard DispatchTime.now() < deadline else {
+            onTimeout()
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            waitForTermination(
+                pid: pid,
+                deadline: deadline,
+                completion: completion,
+                onTimeout: onTimeout
+            )
+        }
+    }
+
+    private static func compatibilityPIDKey(_ bundleID: String) -> String {
+        "chromiumCompatibility.pid.\(bundleID)"
+    }
+
+    private static func legacyCompatibilityPIDKey(_ bundleID: String) -> String {
+        "sourceCompatibility.pid.\(bundleID)"
+    }
+}

--- a/Sources/my-window-pip/SourceWindowActivator.swift
+++ b/Sources/my-window-pip/SourceWindowActivator.swift
@@ -56,6 +56,59 @@ enum SourceWindowActivator {
         return pid_t(number.int32Value)
     }
 
+    /// 生命周期探测：直接查 WindowServer + 进程身份，AX 只负责确认 minimized。
+    /// 调用方应放在低频 utility queue；本函数不会触发权限弹窗。
+    static func lifecycleObservation(
+        of windowID: CGWindowID,
+        expectedPID: pid_t?
+    ) -> SourceWindowObservation {
+        let info = windowInfo(of: windowID)
+        let actualPID = (info?[kCGWindowOwnerPID as String] as? NSNumber)
+            .map { pid_t($0.int32Value) }
+        let probePID = expectedPID ?? actualPID
+        let processAlive = probePID.map(processIsAlive)
+        let ownerPIDMatches: Bool? = {
+            guard let expectedPID, let actualPID else { return nil }
+            return expectedPID == actualPID
+        }()
+        let isOnScreen = (info?[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue
+        let axMinimized: Bool? = {
+            guard let actualPID,
+                  expectedPID == nil || expectedPID == actualPID else { return nil }
+            return minimizedState(of: windowID, pid: actualPID)
+        }()
+        return SourceWindowObservation(
+            cgWindowExists: info != nil,
+            processAlive: processAlive,
+            ownerPIDMatches: ownerPIDMatches,
+            isOnScreen: isOnScreen,
+            axMinimized: axMinimized
+        )
+    }
+
+    /// Returns AX minimized only when Accessibility can answer. No permission prompt.
+    static func minimizedState(of windowID: CGWindowID) -> Bool? {
+        guard let pid = ownerPID(of: windowID) else { return nil }
+        return minimizedState(of: windowID, pid: pid)
+    }
+
+    private static func minimizedState(of windowID: CGWindowID, pid: pid_t) -> Bool? {
+        guard Permissions.hasAccessibility else { return nil }
+        let app = appElement(pid)
+        guard let windows = windows(of: app),
+              let target = exactWindow(id: windowID, in: windows) else { return nil }
+        var raw: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(target, kAXMinimizedAttribute as CFString, &raw) == .success
+        else { return nil }
+        return raw as? Bool
+    }
+
+    private static func processIsAlive(_ pid: pid_t) -> Bool {
+        guard pid > 0 else { return false }
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
     static func activate(windowID: CGWindowID, pid: pid_t, fallbackTitle: String) -> Result {
         guard let runningApp = NSRunningApplication(processIdentifier: pid) else {
             return .applicationNotFound

--- a/Sources/my-window-pip/SourceWindowHealth.swift
+++ b/Sources/my-window-pip/SourceWindowHealth.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Pure lifecycle decision input. System queries should populate this object; policy must stay testable.
+struct SourceWindowObservation: Equatable {
+    let cgWindowExists: Bool?
+    let processAlive: Bool?
+    let ownerPIDMatches: Bool?
+    let isOnScreen: Bool?
+    let axMinimized: Bool?
+}
+
+enum SourceWindowHealth: Equatable {
+    case onScreen
+    case offScreenAlive
+    case minimized
+    case missing
+    case unknown
+}
+
+/// Conservative source-window lifecycle classifier.
+/// Unknown states intentionally preserve PiP rather than closing it.
+func classifySourceWindowHealth(_ observation: SourceWindowObservation) -> SourceWindowHealth {
+    if observation.processAlive == false {
+        return .missing
+    }
+    if observation.ownerPIDMatches == false {
+        return .missing
+    }
+    if observation.axMinimized == true {
+        return .minimized
+    }
+    if observation.cgWindowExists == true {
+        if observation.isOnScreen == true {
+            return .onScreen
+        }
+        if observation.axMinimized == false || observation.processAlive == true {
+            return .offScreenAlive
+        }
+    }
+    // `cgWindowExists` 只能由 WindowServer 的单 windowID 查询填写；false 是窗口 ID 已不存在的
+    // 直接证据，不是 SCK cache miss，因此即使 owner 进程还活着也可以进入 rematch/missing 路径。
+    if observation.cgWindowExists == false {
+        return .missing
+    }
+    return .unknown
+}

--- a/Tests/MyWindowPipTests/AutoHideHoverPolicyTests.swift
+++ b/Tests/MyWindowPipTests/AutoHideHoverPolicyTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import my_window_pip
+
+final class AutoHideHoverPolicyTests: XCTestCase {
+    func testCommandRestoresInteractionForZoomSelection() {
+        let state = HoverState(
+            isHovering: true,
+            isOverHotZone: false,
+            isOverResizeZone: false,
+            optionHeld: false,
+            commandHeld: true
+        )
+        XCTAssertEqual(autoHideHoverIntent(for: state), .command)
+    }
+
+    func testCommandTakesPriorityOverOptionAndResize() {
+        let state = HoverState(
+            isHovering: true,
+            isOverHotZone: true,
+            isOverResizeZone: true,
+            optionHeld: true,
+            commandHeld: true
+        )
+        XCTAssertEqual(autoHideHoverIntent(for: state), .command)
+    }
+
+    func testOptionTakesPriorityOverResize() {
+        let state = HoverState(
+            isHovering: true,
+            isOverHotZone: true,
+            isOverResizeZone: true,
+            optionHeld: true,
+            commandHeld: false
+        )
+        XCTAssertEqual(autoHideHoverIntent(for: state), .option)
+    }
+
+    func testResizeZoneTakesPriorityOverBar() {
+        let state = HoverState(
+            isHovering: true,
+            isOverHotZone: true,
+            isOverResizeZone: true,
+            optionHeld: false,
+            commandHeld: false
+        )
+        XCTAssertEqual(autoHideHoverIntent(for: state), .resize)
+    }
+
+    func testBarRestoresInteractionAwayFromResizeEdge() {
+        let state = HoverState(
+            isHovering: true,
+            isOverHotZone: true,
+            isOverResizeZone: false,
+            optionHeld: false,
+            commandHeld: false
+        )
+        XCTAssertEqual(autoHideHoverIntent(for: state), .bar)
+    }
+
+    func testPlainHoverFadesAndLeavingRestores() {
+        XCTAssertEqual(
+            autoHideHoverIntent(for: HoverState(
+                isHovering: true,
+                isOverHotZone: false,
+                isOverResizeZone: false,
+                optionHeld: false,
+                commandHeld: false
+            )),
+            .fade
+        )
+        XCTAssertEqual(autoHideHoverIntent(for: .none), .leave)
+    }
+
+    func testResizeHotZoneCoversInsideAndOutsideOfEdges() {
+        let frame = CGRect(x: 100, y: 100, width: 400, height: 240)
+        XCTAssertTrue(isInResizeHotZone(
+            point: CGPoint(x: 105, y: 220), frame: frame, thickness: 10
+        ))
+        XCTAssertTrue(isInResizeHotZone(
+            point: CGPoint(x: 506, y: 220), frame: frame, thickness: 10
+        ))
+        XCTAssertTrue(isInResizeHotZone(
+            point: CGPoint(x: 95, y: 95), frame: frame, thickness: 10
+        ))
+    }
+
+    func testResizeHotZoneDoesNotStealContentCenterOrFarOutside() {
+        let frame = CGRect(x: 100, y: 100, width: 400, height: 240)
+        XCTAssertFalse(isInResizeHotZone(
+            point: CGPoint(x: 300, y: 220), frame: frame, thickness: 10
+        ))
+        XCTAssertFalse(isInResizeHotZone(
+            point: CGPoint(x: 80, y: 220), frame: frame, thickness: 10
+        ))
+    }
+}

--- a/Tests/MyWindowPipTests/CaptureConfigurationTests.swift
+++ b/Tests/MyWindowPipTests/CaptureConfigurationTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import my_window_pip
+
+final class CaptureConfigurationTests: XCTestCase {
+    func testFullWindowCapturePreservesAspectRatioAndRendererCropsPadding() {
+        let config = CaptureEngine.makeConfiguration(
+            sourceRect: .zero,
+            pointSize: CGSize(width: 480, height: 270),
+            scale: 2,
+            fps: 15,
+            showsCursor: false
+        )
+        XCTAssertTrue(config.scalesToFit)
+        XCTAssertTrue(config.preservesAspectRatio)
+    }
+
+    func testCroppedCaptureStillPreservesAspectRatio() {
+        let config = CaptureEngine.makeConfiguration(
+            sourceRect: CGRect(x: 100, y: 80, width: 960, height: 540),
+            pointSize: CGSize(width: 480, height: 270),
+            scale: 2,
+            fps: 15,
+            showsCursor: false
+        )
+        XCTAssertTrue(config.scalesToFit)
+        XCTAssertTrue(config.preservesAspectRatio)
+    }
+
+    func testContentGeometryChoosesScaleFactorWhenRectIsAlreadyInSurfacePoints() {
+        let visible = FrameGate.resolvedVisibleRectPixels(
+            contentRect: CGRect(x: 0, y: 5, width: 480, height: 260),
+            scaleFactor: 2,
+            contentScale: 0.25,
+            bufferSize: CGSize(width: 960, height: 540)
+        )
+        XCTAssertEqual(visible?.origin.x ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual(visible?.origin.y ?? -1, 10, accuracy: 0.001)
+        XCTAssertEqual(visible?.width ?? 0, 960, accuracy: 0.001)
+        XCTAssertEqual(visible?.height ?? 0, 520, accuracy: 0.001)
+    }
+
+    func testContentGeometryUsesContentScaleWhenRawRectIsSourceSized() {
+        let visible = FrameGate.resolvedVisibleRectPixels(
+            contentRect: CGRect(x: 0, y: 20, width: 1920, height: 1040),
+            scaleFactor: 2,
+            contentScale: 0.25,
+            bufferSize: CGSize(width: 960, height: 540)
+        )
+        XCTAssertEqual(visible?.origin.x ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual(visible?.origin.y ?? -1, 10, accuracy: 0.001)
+        XCTAssertEqual(visible?.width ?? 0, 960, accuracy: 0.001)
+        XCTAssertEqual(visible?.height ?? 0, 520, accuracy: 0.001)
+    }
+}

--- a/Tests/MyWindowPipTests/GeometrySelectionTests.swift
+++ b/Tests/MyWindowPipTests/GeometrySelectionTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import my_window_pip
+
+final class GeometrySelectionTests: XCTestCase {
+    func testCmdSelectionKeepsItsOwnAspectRatio() {
+        let bounds = CGRect(x: 0, y: 0, width: 480, height: 270)
+        let selection = CGRect(x: 120, y: 45, width: 120, height: 180)
+
+        let normalized = Geo.visibleNormalizedRect(
+            forSelection: selection,
+            aspect: CGSize(width: 16, height: 9),
+            bounds: bounds
+        )
+        XCTAssertNotNil(normalized)
+
+        let source = normalized.flatMap {
+            Geo.sourceRect(
+                fromNormalizedVisibleRect: $0,
+                within: CGRect(x: 0, y: 0, width: 1920, height: 1080)
+            )
+        }
+        XCTAssertNotNil(source)
+        XCTAssertEqual(source?.minX ?? 0, 480, accuracy: 0.001)
+        XCTAssertEqual(source?.minY ?? 0, 180, accuracy: 0.001)
+        XCTAssertEqual(source?.width ?? 0, 480, accuracy: 0.001)
+        XCTAssertEqual(source?.height ?? 0, 720, accuracy: 0.001)
+        XCTAssertEqual((source?.width ?? 0) / (source?.height ?? 1), 2.0 / 3.0, accuracy: 0.001)
+    }
+
+    func testSelectedCropRemapsAcrossSourceResize() {
+        let oldBase = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let selected = CGRect(x: 480, y: 180, width: 480, height: 720)
+        let newBase = CGRect(x: 0, y: 0, width: 1440, height: 900)
+
+        let mapped = Geo.remap(selected, from: oldBase, to: newBase)
+        XCTAssertNotNil(mapped)
+        XCTAssertEqual(mapped?.minX ?? 0, 360, accuracy: 0.001)
+        XCTAssertEqual(mapped?.minY ?? 0, 150, accuracy: 0.001)
+        XCTAssertEqual(mapped?.width ?? 0, 360, accuracy: 0.001)
+        XCTAssertEqual(mapped?.height ?? 0, 600, accuracy: 0.001)
+        XCTAssertEqual((mapped?.width ?? 0) / (mapped?.height ?? 1), 0.6, accuracy: 0.001)
+    }
+
+    func testDisplayLayerFrameCropsTopAndRightSurfacePadding() {
+        let frame = Geo.displayLayerFrame(
+            bufferSize: CGSize(width: 1000, height: 600),
+            visibleRectPixels: CGRect(x: 0, y: 10, width: 990, height: 590),
+            in: CGRect(x: 0, y: 0, width: 495, height: 295)
+        )
+
+        XCTAssertNotNil(frame)
+        // visible rect 的左/下边正好落在 view 左/下；surface 多出的 top/right 被推出裁剪区。
+        XCTAssertEqual(frame?.minX ?? 1, 0, accuracy: 0.001)
+        XCTAssertEqual(frame?.minY ?? 1, 0, accuracy: 0.001)
+        XCTAssertEqual(frame?.width ?? 0, 500, accuracy: 0.001)
+        XCTAssertEqual(frame?.height ?? 0, 300, accuracy: 0.001)
+    }
+
+    func testDisplayLayerFrameAccountsForLeftAndBottomPadding() {
+        let frame = Geo.displayLayerFrame(
+            bufferSize: CGSize(width: 1000, height: 600),
+            visibleRectPixels: CGRect(x: 10, y: 0, width: 990, height: 590),
+            in: CGRect(x: 0, y: 0, width: 495, height: 295)
+        )
+
+        XCTAssertNotNil(frame)
+        XCTAssertEqual(frame?.minX ?? 0, -5, accuracy: 0.001)
+        XCTAssertEqual(frame?.minY ?? 0, -5, accuracy: 0.001)
+        XCTAssertEqual(frame?.width ?? 0, 500, accuracy: 0.001)
+        XCTAssertEqual(frame?.height ?? 0, 300, accuracy: 0.001)
+    }
+}

--- a/Tests/MyWindowPipTests/InitialPiPWidthTests.swift
+++ b/Tests/MyWindowPipTests/InitialPiPWidthTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import my_window_pip
+
+final class InitialPiPWidthTests: XCTestCase {
+    func testFullscreenWindowUsesCompactDefaultWidth() {
+        let width = Geo.initialPiPWidth(
+            sourceSize: CGSize(width: 1920, height: 1080),
+            rememberedWidth: nil,
+            screenSizes: [CGSize(width: 1920, height: 1080)],
+            isWindowSource: true
+        )
+        XCTAssertEqual(width, 480, accuracy: 0.001)
+    }
+
+    func testLegacyFullscreenDefault640MigratesToCompactWidth() {
+        let width = Geo.initialPiPWidth(
+            sourceSize: CGSize(width: 1920, height: 1080),
+            rememberedWidth: 640,
+            screenSizes: [CGSize(width: 1920, height: 1080)],
+            isWindowSource: true
+        )
+        XCTAssertEqual(width, 480, accuracy: 0.001)
+    }
+
+    func testExplicitNonLegacyRememberedWidthIsPreservedForFullscreen() {
+        let width = Geo.initialPiPWidth(
+            sourceSize: CGSize(width: 1920, height: 1080),
+            rememberedWidth: 560,
+            screenSizes: [CGSize(width: 1920, height: 1080)],
+            isWindowSource: true
+        )
+        XCTAssertEqual(width, 560, accuracy: 0.001)
+    }
+
+    func testNormalWindowKeepsExistingDefaultPolicy() {
+        let width = Geo.initialPiPWidth(
+            sourceSize: CGSize(width: 1200, height: 800),
+            rememberedWidth: nil,
+            screenSizes: [CGSize(width: 1920, height: 1080)],
+            isWindowSource: true
+        )
+        XCTAssertEqual(width, 600, accuracy: 0.001)
+    }
+
+    func testRegionCaptureDoesNotUseFullscreenWindowRule() {
+        let width = Geo.initialPiPWidth(
+            sourceSize: CGSize(width: 1920, height: 1080),
+            rememberedWidth: nil,
+            screenSizes: [CGSize(width: 1920, height: 1080)],
+            isWindowSource: false
+        )
+        XCTAssertEqual(width, 640, accuracy: 0.001)
+    }
+
+    func testFullscreenMainWindowCountsAsScreenFilling() {
+        XCTAssertTrue(Geo.isScreenFillingWindow(
+            size: CGSize(width: 1920, height: 1080),
+            screenSizes: [CGSize(width: 1920, height: 1080)]
+        ))
+    }
+
+    func testWideChromeAuxiliarySurfaceDoesNotCountAsScreenFilling() {
+        XCTAssertFalse(Geo.isScreenFillingWindow(
+            size: CGSize(width: 1920, height: 132),
+            screenSizes: [CGSize(width: 1920, height: 1080)]
+        ))
+    }
+
+    func testSplitScreenWindowDoesNotStealFullscreenPriority() {
+        XCTAssertFalse(Geo.isScreenFillingWindow(
+            size: CGSize(width: 960, height: 972),
+            screenSizes: [CGSize(width: 1920, height: 1080)]
+        ))
+    }
+}

--- a/Tests/MyWindowPipTests/SourceAppCompatibilityTests.swift
+++ b/Tests/MyWindowPipTests/SourceAppCompatibilityTests.swift
@@ -1,0 +1,140 @@
+import Darwin
+import XCTest
+@testable import my_window_pip
+
+final class SourceAppCompatibilityTests: XCTestCase {
+    func testChatGPTHasVerifiedCompatibilityProfile() {
+        let profile = SourceAppCompatibility.profile(for: "com.openai.codex")
+        XCTAssertEqual(profile?.appName, "ChatGPT")
+        XCTAssertEqual(
+            profile?.launchArguments,
+            ["--disable-backgrounding-occluded-windows"]
+        )
+    }
+
+    func testChromeHasVerifiedCompatibilityProfile() {
+        let profile = SourceAppCompatibility.profile(for: "com.google.Chrome")
+        XCTAssertEqual(profile?.appName, "Google Chrome")
+        XCTAssertEqual(profile?.isVerified, true)
+        XCTAssertEqual(
+            profile?.launchArguments,
+            ["--disable-backgrounding-occluded-windows"]
+        )
+    }
+
+    func testUnknownApplicationsDoNotGetStaticCompatibilityArguments() {
+        XCTAssertNil(SourceAppCompatibility.profile(for: "com.example.NativeApp"))
+        XCTAssertNil(SourceAppCompatibility.profile(for: nil))
+    }
+
+    func testVerifiedAppNamesComeFromAllowlist() {
+        XCTAssertEqual(SourceAppCompatibility.verifiedAppNames, ["ChatGPT", "Google Chrome"])
+    }
+
+    func testElectronFrameworkIsEnoughForConservativeDetection() {
+        XCTAssertTrue(SourceAppCompatibility.isChromiumLike(.init(
+            hasElectronFramework: true,
+            hasElectronAsar: false,
+            hasRendererHelper: false,
+            hasResourcesPak: false,
+            hasICUData: false
+        )))
+    }
+
+    func testChromiumRuntimeSignatureRequiresRendererAndResources() {
+        XCTAssertTrue(SourceAppCompatibility.isChromiumLike(.init(
+            hasElectronFramework: false,
+            hasElectronAsar: false,
+            hasRendererHelper: true,
+            hasResourcesPak: true,
+            hasICUData: true
+        )))
+        XCTAssertFalse(SourceAppCompatibility.isChromiumLike(.init(
+            hasElectronFramework: false,
+            hasElectronAsar: false,
+            hasRendererHelper: true,
+            hasResourcesPak: true,
+            hasICUData: false
+        )))
+    }
+
+    func testKernProcArgsParserFindsCompatibilityArgument() {
+        var argc: Int32 = 3
+        var bytes: [UInt8] = []
+        withUnsafeBytes(of: &argc) { bytes.append(contentsOf: $0) }
+
+        func appendCString(_ value: String) {
+            bytes.append(contentsOf: value.utf8)
+            bytes.append(0)
+        }
+
+        appendCString("/Applications/Test.app/Contents/MacOS/Test")
+        bytes.append(0) // executable path 与 argv 之间的 padding
+        appendCString("Test")
+        appendCString("--disable-backgrounding-occluded-windows")
+        appendCString("--other")
+
+        XCTAssertEqual(
+            SourceAppCompatibility.parseProcessArgumentsBuffer(bytes),
+            ["Test", "--disable-backgrounding-occluded-windows", "--other"]
+        )
+    }
+
+    func testProcessArgumentsCanReadCurrentProcess() {
+        let arguments = SourceAppCompatibility.processArguments(pid: getpid())
+        XCTAssertNotNil(arguments)
+        XCTAssertFalse(arguments?.isEmpty ?? true)
+    }
+
+    func testCompatibilityArgumentsAreAppendedToExistingLaunchArguments() {
+        XCTAssertEqual(
+            SourceAppCompatibility.launchArgumentsByAppendingCompatibility(
+                processArguments: [
+                    "Google Chrome",
+                    "--variations-override-country=us",
+                    "--profile-directory=Default",
+                ],
+                compatibilityArguments: ["--disable-backgrounding-occluded-windows"]
+            ),
+            [
+                "--variations-override-country=us",
+                "--profile-directory=Default",
+                "--disable-backgrounding-occluded-windows",
+            ]
+        )
+    }
+
+    func testCompatibilityAppendDoesNotDuplicateExistingArgument() {
+        XCTAssertEqual(
+            SourceAppCompatibility.launchArgumentsByAppendingCompatibility(
+                processArguments: [
+                    "ChatGPT",
+                    "--disable-backgrounding-occluded-windows",
+                ],
+                compatibilityArguments: ["--disable-backgrounding-occluded-windows"]
+            ),
+            ["--disable-backgrounding-occluded-windows"]
+        )
+    }
+
+    func testCompatibilityAppendFallsBackToCompatibilityArgumentsWhenArgvUnavailable() {
+        XCTAssertEqual(
+            SourceAppCompatibility.launchArgumentsByAppendingCompatibility(
+                processArguments: nil,
+                compatibilityArguments: ["--disable-backgrounding-occluded-windows"]
+            ),
+            ["--disable-backgrounding-occluded-windows"]
+        )
+    }
+
+    func testChromiumCompatibilityPreferenceRoundTrips() {
+        let prefs = Preferences.shared
+        let original = prefs.chromiumCompatibilityMode
+        defer { prefs.chromiumCompatibilityMode = original }
+
+        for mode in ChromiumCompatibilityMode.allCases {
+            prefs.chromiumCompatibilityMode = mode
+            XCTAssertEqual(prefs.chromiumCompatibilityMode, mode)
+        }
+    }
+}

--- a/Tests/MyWindowPipTests/SourceWindowHealthTests.swift
+++ b/Tests/MyWindowPipTests/SourceWindowHealthTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import my_window_pip
+
+final class SourceWindowHealthTests: XCTestCase {
+    func testOffscreenAliveDoesNotBecomeMissing() {
+        let result = classifySourceWindowHealth(SourceWindowObservation(
+            cgWindowExists: true,
+            processAlive: true,
+            ownerPIDMatches: true,
+            isOnScreen: false,
+            axMinimized: false
+        ))
+        XCTAssertEqual(result, .offScreenAlive)
+    }
+
+    func testAXMinimizedIsRequiredForMinimizedState() {
+        let result = classifySourceWindowHealth(SourceWindowObservation(
+            cgWindowExists: true,
+            processAlive: true,
+            ownerPIDMatches: true,
+            isOnScreen: false,
+            axMinimized: true
+        ))
+        XCTAssertEqual(result, .minimized)
+    }
+
+    func testNoAXPermissionFallsBackToAlive() {
+        let result = classifySourceWindowHealth(SourceWindowObservation(
+            cgWindowExists: true,
+            processAlive: true,
+            ownerPIDMatches: true,
+            isOnScreen: false,
+            axMinimized: nil
+        ))
+        XCTAssertEqual(result, .offScreenAlive)
+    }
+
+    func testDirectWindowServerMissIsMissingEvenWhenProcessLives() {
+        let result = classifySourceWindowHealth(SourceWindowObservation(
+            cgWindowExists: false,
+            processAlive: true,
+            ownerPIDMatches: nil,
+            isOnScreen: nil,
+            axMinimized: nil
+        ))
+        XCTAssertEqual(result, .missing)
+    }
+
+    func testDeadProcessIsMissing() {
+        let result = classifySourceWindowHealth(SourceWindowObservation(
+            cgWindowExists: false,
+            processAlive: false,
+            ownerPIDMatches: false,
+            isOnScreen: false,
+            axMinimized: nil
+        ))
+        XCTAssertEqual(result, .missing)
+    }
+
+    func testOwnerPIDMismatchIsMissing() {
+        let result = classifySourceWindowHealth(SourceWindowObservation(
+            cgWindowExists: true,
+            processAlive: true,
+            ownerPIDMatches: false,
+            isOnScreen: true,
+            axMinimized: nil
+        ))
+        XCTAssertEqual(result, .missing)
+    }
+}


### PR DESCRIPTION
## Summary

- keep window PiP sessions alive across inactive Spaces by separating transport stalls from source lifecycle and classifying source health with WindowServer/Accessibility evidence
- improve all-Space window discovery/fullscreen target selection and crop dynamic ScreenCaptureKit surface padding from per-frame metadata
- add Chromium/Electron compatibility relaunch support for apps that stop repainting offscreen, while closing existing PiPs before relaunch and preserving existing launch arguments when available
- make Cmd-drag selection use the selected region's own aspect ratio, and keep auto-hide PiPs resizable with edge/corner hot zones plus live-resize locking

## Validation

- `swift test` — 53 tests passed
- `swift build`
- `bash scripts/build-app.sh --fast`
- `git diff --check`