### PR TITLE
fix: 避免首次录屏授权与应用引导叠加

### DIFF
--- a/Sources/my-window-pip/AppDelegate.swift
+++ b/Sources/my-window-pip/AppDelegate.swift
@@ -26,15 +26,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Log.warn("增强模式无法启用（辅助功能权限缺失），已回退到零权限模式")
         }
 
-        // 首次运行且未授权时：先向系统申请（这一步会弹系统授权框，并把本应用登记进
-        // 「屏幕录制与系统录音」列表，用户直接开开关即可，不用手动点加号），
-        // 仍未授权才显示我们的引导框。菜单栏的告警项会在下次打开菜单时自动消失。
-        if !Permissions.hasScreenRecording {
+        // 首次运行且未授权时只向系统申请（会弹系统授权框，并把本应用登记进
+        // 「屏幕录制与系统录音」列表）；App 自己的引导留到用户之后仍主动触发捕获时，
+        // 避免两层弹窗叠在一起。菜单栏的告警项会在下次打开菜单时自动消失。
+        let hadScreenRecordingPermission = Permissions.hasScreenRecording
+        if !hadScreenRecordingPermission {
             Permissions.ensureScreenRecording()
         }
 
-        // 权限流程走完之后再弹首启引导，避免和系统授权框叠弹
-        if !Preferences.shared.hasSeenOnboarding {
+        // 未授权的首次启动只显示系统授权框；上手引导留到授权并重启后，避免两层 UI 叠弹。
+        if hadScreenRecordingPermission, !Preferences.shared.hasSeenOnboarding {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
                 self?.showOnboarding(markAsSeen: true)
             }

--- a/Sources/my-window-pip/Permissions.swift
+++ b/Sources/my-window-pip/Permissions.swift
@@ -7,12 +7,25 @@ enum Permissions {
 
     // MARK: - 屏幕录制
 
+    /// 原子记录本进程是否已经触发过系统授权请求，避免并发入口重复请求或叠加 App 引导。
+    private final class ScreenRecordingRequestState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didRequest = false
+
+        /// 首个调用方把状态置为已请求并返回 true；后续调用返回 false。
+        func beginRequestIfNeeded() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didRequest else { return false }
+            didRequest = true
+            return true
+        }
+    }
+
+    private static let screenRecordingRequestState = ScreenRecordingRequestState()
+
     /// 不弹窗的预检。
     static var hasScreenRecording: Bool { CGPreflightScreenCaptureAccess() }
-
-    /// 首次调用会触发系统授权弹窗；已被拒绝时直接返回 false。
-    @discardableResult
-    static func requestScreenRecording() -> Bool { CGRequestScreenCaptureAccess() }
 
     /// 让系统把本应用登记进「屏幕录制与系统录音」列表。
     ///
@@ -22,7 +35,7 @@ enum Permissions {
     /// 1. `CGRequestScreenCaptureAccess()` 触发系统授权弹窗并写入 TCC 条目
     /// 2. 再发一次 ScreenCaptureKit 查询，确保 SCK 侧也完成登记（失败被系统吞掉是正常的）
     @discardableResult
-    static func primeRegistration() -> Bool {
+    private static func primeRegistration() -> Bool {
         let granted = CGRequestScreenCaptureAccess()
         Task.detached(priority: .utility) {
             _ = try? await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
@@ -30,13 +43,19 @@ enum Permissions {
         return granted
     }
 
-    /// 确保拥有屏幕录制权限：先向系统申请（顺带完成列表登记），仍未授权才显示引导。
+    /// 确保拥有屏幕录制权限。
+    ///
+    /// 首次调用只发起 macOS 系统授权：系统弹窗是实际授予 TCC 权限的唯一入口，不与 App
+    /// 自己的说明框叠加。若本次启动已经请求过、用户之后仍主动触发捕获或点击权限菜单，
+    /// 才显示 App 引导，提供系统设置、重置记录与重启入口。
     @discardableResult
     static func ensureScreenRecording() -> Bool {
         if hasScreenRecording { return true }
-        if primeRegistration() { return true }
-        // 系统弹窗是异步的，用户可能刚点了「允许」，复检一次避免多弹一个框
-        if hasScreenRecording { return true }
+        if screenRecordingRequestState.beginRequestIfNeeded() {
+            _ = primeRegistration()
+            // 系统授权可能要求重启应用才生效；这里只复检，不在同一轮再弹 App 引导。
+            return hasScreenRecording
+        }
         showScreenRecordingGuide()
         return false
     }


### PR DESCRIPTION
未获得录屏权限时，启动流程会在向 macOS 请求授权后立即显示应用自己的权限说明，并在 0.6 秒后再显示首启引导。系统授权尚未结束时，这些界面可能叠加，让首次授权流程不清晰。

本改动按进程记录是否已发起过录屏授权请求：首次调用只请求系统授权并复检权限；同次启动中，用户之后再次主动捕获或点击权限菜单，仍未授权时才显示应用说明。首启引导只在启动时已经有录屏权限的情况下自动显示；未授权的启动不会把引导标记为已读。

保留系统登记、系统设置、重置记录和重启入口。该 PR 仅提取 fork 中的权限与首启引导修复，可直接基于上游 main 独立合并。

验证：`swift test --disable-sandbox -Xswiftc -warnings-as-errors`（完整测试套件）。本次没有重置真实 TCC 授权记录，系统授权弹窗的首次启动流程未重新实测。人工验证步骤：未授权启动仅出现系统授权；拒绝后主动捕获出现应用说明；授权并重启后显示未读首启引导。
