### PR TITLE
fix: 排除附属窗口以稳定会话切换时的 PiP 画面

### DIFF
--- a/Sources/my-window-pip/CaptureEngine.swift
+++ b/Sources/my-window-pip/CaptureEngine.swift
@@ -124,7 +124,9 @@ final class CaptureEngine: NSObject, SCStreamOutput, SCStreamDelegate {
         // 单窗口捕获默认会带上窗口阴影，浮窗里会显示成一圈半透明边，去掉更干净
         cfg.ignoreShadowsSingleWindow = true
         if #available(macOS 14.2, *) {
-            cfg.includeChildWindows = true                   // 抽屉/弹出面板也一起进画面
+            // PiP 的几何基准是选中的主窗口。附属窗口可能超出其边界；一起捕获会
+            // 扩大内容范围，并在 scalesToFit 下把主画面缩小，即使浮窗外框不变。
+            cfg.includeChildWindows = false
         }
         return cfg
     }

--- a/Tests/MyWindowPipTests/CaptureConfigurationTests.swift
+++ b/Tests/MyWindowPipTests/CaptureConfigurationTests.swift
@@ -2,6 +2,23 @@ import XCTest
 @testable import my_window_pip
 
 final class CaptureConfigurationTests: XCTestCase {
+    func testRetuningCaptureKeepsChildWindowsExcluded() throws {
+        guard #available(macOS 14.2, *) else {
+            throw XCTSkip("Child-window capture configuration requires macOS 14.2")
+        }
+        // 同一配置入口用于建流、放大、复位、跨屏和重连；这些更新不能重新扩大捕获范围。
+        let crop = CGRect(x: 100, y: 80, width: 960, height: 540)
+        for (rect, scale, fps) in [(CGRect.zero, 1.0, 5), (crop, 2.0, 15), (.zero, 2.0, 30)] {
+            let config = CaptureEngine.makeConfiguration(
+                sourceRect: rect, pointSize: CGSize(width: 640, height: 360),
+                scale: scale, fps: fps, showsCursor: false
+            )
+            XCTAssertFalse(config.includeChildWindows)
+            XCTAssertEqual(config.sourceRect, rect)
+            XCTAssertTrue(config.preservesAspectRatio)
+        }
+    }
+
     func testFullWindowCapturePreservesAspectRatioAndRendererCropsPadding() {
         let config = CaptureEngine.makeConfiguration(
             sourceRect: .zero,


### PR DESCRIPTION
当 ChatGPT 的会话带有 Computer Use 等附属窗口时，`includeChildWindows = true` 会把超出主窗口边界的附属内容一起纳入捕获范围，导致切换会话时 PiP 画面缩小或比例变化，即使主窗口尺寸没有变化。

在 macOS 14.2 及以上将 `includeChildWindows` 设为 `false`，使捕获范围保持在选中的主窗口。新增配置回归测试，覆盖整窗、裁剪、不同缩放和帧率下始终排除附属窗口。

行为取舍：独立附属窗口（例如 Computer Use 小窗口、抽屉或弹出面板）不再进入 PiP；直接绘制在主窗口内部的内容仍会显示。macOS 14.0–14.1 的配置行为不变。

此修复已在 fork 中合并并由用户实际切换会话验证通过。本 PR 直接基于上游 main，只包含捕获配置及对应测试，不依赖 fork 的其他几何修正。

验证：`swift test --disable-sandbox -Xswiftc -warnings-as-errors`（完整测试套件）；用户已验证 fork 合并版本的会话切换。独立上游版本未重新进行 GUI 实测。
